### PR TITLE
Replaced FKGPUFilterGroup with GPUImageFilterGroup

### DIFF
--- a/2013-05-06-gpuimage.md
+++ b/2013-05-06-gpuimage.md
@@ -258,7 +258,7 @@ GPUImageView *filteredVideoView = [[GPUImageView alloc] initWithFrame:self.view.
 Or, combining various color blending modes, image effects, and adjustments, you could transform still images into something worthy of sharing with your hipster friends (example taken from [FilterKit](https://github.com/eklipse2k8/FilterKit/blob/master/FilterKit/FilterKit/Filters/FKBlueValentine.m), which is built on GPUImage):
 
 ~~~{objective-c}
-GPUImageFilterGroup *filter = [[FKGPUFilterGroup alloc] init];
+GPUImageFilterGroup *filter = [[GPUImageFilterGroup alloc] init];
 
 GPUImageSaturationFilter *saturationFilter = [[GPUImageSaturationFilter alloc] init];
 [saturationFilter setSaturation:0.5];


### PR DESCRIPTION
Got rid of a FilterKit class that should not be there and replaced it with the equivalent GPUImage class.
