### PR TITLE
Update 2012-08-13-nsincrementalstore.md

### DIFF
--- a/2012-08-13-nsincrementalstore.md
+++ b/2012-08-13-nsincrementalstore.md
@@ -80,7 +80,7 @@ This method requires very specific and very different return values depending on
 
 - Result Type: `NSCountResultType`
   
-> **Return**: `NSNumber` of count of objects matching request
+> **Return**: `NSArray` containing one `NSNumber` of count of objects matching request (not `NSNumber` as mentioned here before)
 
 #### Request Type: `NSSaveRequestType`
   


### PR DESCRIPTION
Fixed return type of `-executeRequest:withContext:error:` if `resultType` is `NSCountResultType` from `NSNumber` to `NSArray` containing a `NSNumber`.

[Source](http://developer.apple.com/library/ios/documentation/CoreData/Reference/NSIncrementalStore_Class/Reference/NSIncrementalStore.html#//apple_ref/occ/instm/NSIncrementalStore/executeRequest:withContext:error:)
