### PR TITLE
[minor] Fix indentation in NSDataDetectors example code

### DIFF
--- a/2013-06-02-nsdatadetector.md
+++ b/2013-06-02-nsdatadetector.md
@@ -27,9 +27,9 @@ You can think of it as a regexp matcher with incredibly complicated expressions 
 
 ~~~{objective-c}
 NSError *error = nil;
-NSDataDetector *detector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink |
-                      NSTextCheckingTypePhoneNumber
-                error:&error];
+NSDataDetector *detector = [NSDataDetector dataDetectorWithTypes:NSTextCheckingTypeLink
+                                                        | NSTextCheckingTypePhoneNumber
+                                                           error:&error];
 
 NSString *string = @"123 Main St. / (555) 555-5555";
 [detector enumerateMatchesInString:string


### PR DESCRIPTION
![screen shot 2013-06-06 at 01 21 34](https://f.cloud.github.com/assets/49038/615580/164c301c-ce3f-11e2-8c9b-2029ea1238b5.png)

I've aligned the spacing of the `NSDataDetector dataDetectorWithTypes:` method call for better visual pleasing-ness. I couldn't confirm as I don't have the whole Jekyll setup but I'd expect it to look better.
