### PR TITLE
Fixed typos in ReactiveCocoa and NSCoding articles

### DIFF
--- a/2013-02-18-reactivecocoa.md
+++ b/2013-02-18-reactivecocoa.md
@@ -18,7 +18,7 @@ Objective-C has a remarkable history spanning four acts in as many decades:
 
 **In its 3<sup>rd</sup> act**, Objective-C rose to unprecedented significance with the release of iOS, making it the most important language of mobile computing.
 
-**Objective-C's 4<sup>th</sup> act takes us to the present day**, with an influx of new iOS developers from the Ruby, Python, and Javascript communities sparked a revolution open source participation. For the first time, Objective-C is being directly shaped and guided by the contributions of individuals outside of Apple.
+**Objective-C's 4<sup>th</sup> act takes us to the present day**, with an influx of new iOS developers from the Ruby, Python, and Javascript communities sparking a revolution in open source participation. For the first time, Objective-C is being directly shaped and guided by the contributions of individuals outside of Apple.
 
 Breaking from a tradition of covering Apple APIs exclusively, this edition of NSHipster will look at an open source project that exemplifies this brave new era for Objective-C: [ReactiveCocoa](https://github.com/ReactiveCocoa/ReactiveCocoa).
 

--- a/2013-05-13-nscoding.md
+++ b/2013-05-13-nscoding.md
@@ -84,7 +84,7 @@ Et cetera. In a heads-up, apples to apples comparison, it looks rather one-sided
   </tbody>
 </table>
 
-By these measure, `NSKeyedArchiver` becomes a perfectly reasonable choice in certain situations. Not all apps need to query data. Not all apps need automatic migrations. Not all apps work with large or complex object graphs. And even apps that do may have certain components better served by a simpler solution.
+By these measures, `NSKeyedArchiver` becomes a perfectly reasonable choice in certain situations. Not all apps need to query data. Not all apps need automatic migrations. Not all apps work with large or complex object graphs. And even apps that do may have certain components better served by a simpler solution.
 
 This article will look at the how's, when's, and why's of `NSKeyedArchiver` and `NSCoding`. And with this understanding, hopefully provide you, dear reader, with the wisdom to choose the best tool for the job.
 


### PR DESCRIPTION
What it says on the tin; I fixed typos in those two articles.
