### PR TITLE
Update 2013-08-26-equality.md

### DIFF
--- a/2013-08-26-equality.md
+++ b/2013-08-26-equality.md
@@ -105,7 +105,7 @@ Let it be perfectly clear that the correct way to compare `NSString` objects is 
 
 So what's going on here? Why does this work, when the same code for `NSArray` or `NSDictionary` literals wouldn't work?
 
-It all has to do with an optimization technique known as [string interning](http://en.wikipedia.org/wiki/String_interning), whereby one copy of immutable string value is copied for each distinct value. `NSString *a` and `*b` point to the same copy of the interned string value `@"Hello"`. _Note that this only works for _immutable_ strings._
+It all has to do with an optimization technique known as [string interning](http://en.wikipedia.org/wiki/String_interning), whereby one copy of immutable string value is copied for each distinct value. `NSString *a` and `*b` point to the same copy of the interned string value `@"Hello"`. _Note that this only works for statically defined immutable strings._
 
 Interestingly enough, Objective-C selector names are also stored as interned strings in a shared string pool. 
 


### PR DESCRIPTION
This does not hold true for all immutable strings, only for those that are statically defined. Here is a simple counter example:
# import <Foundation/Foundation.h>

int main(int argc, char \* argv[]) {
    @autoreleasepool {

```
    NSString * a = @"Hello";
    NSString * b = @"Hello";

    NSMutableString * c = [[NSMutableString alloc] init];
    [c appendString:@"Hel"];
    [c appendString:@"lo"];

    NSString * d = [[NSString alloc] initWithString:c];

    NSLog(@"a == b: %d", a == b);
    NSLog(@"a == d: %d", a == d);

}
```

}
