### PR TITLE
Fixed smile detection example

### DIFF
--- a/2013-09-23-ios7.md
+++ b/2013-09-23-ios7.md
@@ -113,12 +113,12 @@ In yet another free app idea, here's a snippet that might be used by a camera th
 ~~~
 
 ~~~{objective-c}
-CIDetector *smileDetector = [CIDetector detectorOfType:CIDetectorSmile 
+CIDetector *smileDetector = [CIDetector detectorOfType:CIDetectorTypeFace
                                 context:context 
                                 options:@{CIDetectorTracking: @YES, 
                                           CIDetectorAccuracy: CIDetectorAccuracyLow}];
-NSArray *features = [smileDetector featuresInImage:image];
-if ([features count] > 0) {
+NSArray *features = [smileDetector featuresInImage:image options:@{CIDetectorSmile:@YES}];
+if (([features count] > 0) && (((CIFaceFeature *)features[0]).hasSmile)) {
     UIImageWriteToSavedPhotosAlbum(image, self, @selector(didFinishWritingImage), features);
 } else {
     self.label.text = @"Say Cheese!"


### PR DESCRIPTION
The example for smile detection has a few errors.
1) When creating the detector, you need to pass in CIDectorTypeFace not CIDetectorSmile.
2) You need to pass in CIDetectorSmile as an option to `featuresInImage:options:` to actually turn on smile detection (it's performed as an additional step when finding faces).
3) Once you have a CIFaceFeature, you need to check the hasSmile property to see if a smile has been detected. In the sample, I'm just checking the first face.
