### PR TITLE
Improved producing NSError example

### DIFF
--- a/2013-10-14-nserror.md
+++ b/2013-10-14-nserror.md
@@ -134,12 +134,12 @@ To pass an error to an `NSError **` parameter, do the following:
                  error:(NSError * __autoreleasing *)error
 {
     // ...
-
-    if (error) {
-      *error = [NSError errorWithDomain:NSHipsterErrorDomain 
-                                   code:-42
-                               userInfo:nil];
-
+    if (somethingNastyHappened) {
+      if (error) {
+        *error = [NSError errorWithDomain:NSHipsterErrorDomain 
+                                    code:-42
+                                userInfo:nil];
+      }
       return NO;
     }
 


### PR DESCRIPTION
In the example it looked like in case a `NSError **` parameter is not passed, we should just return `YES`, whereas we should return `NO` in any case and just avoid to dereference the pointer.
