### PR TITLE
Update 2013-10-14-nserror.md

### DIFF
--- a/2013-10-14-nserror.md
+++ b/2013-10-14-nserror.md
@@ -115,7 +115,7 @@ NSURLRequest *request = [NSURLRequest requestWithURL:URL];
 NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
 [[session dataTaskWithRequest:request
             completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-    if (error) {
+    if (data == nil) {
         NSLog(@"%@", error);
     } else {
         // ...
@@ -135,7 +135,7 @@ To pass an error to an `NSError **` parameter, do the following:
 {
     // ...
 
-    if (error) {
+    if (object == nil) {
       *error = [NSError errorWithDomain:NSHipsterErrorDomain 
                                    code:-42
                                userInfo:nil];


### PR DESCRIPTION
Mark Dalrymple makes a [good point](http://blog.bignerdranch.com/360-an-nserror-error/) that comparing against an NSError can be risky business. 

I'm not sure how you feel about (object == nil) vs. (!object) but chose the former for clarity.
