### PR TITLE
Fixed AVCaptureMetaDataOutput example in iOS 7 article

### DIFF
--- a/2013-09-23-ios7.md
+++ b/2013-09-23-ios7.md
@@ -147,9 +147,9 @@ if (input) {
 }
 
 AVCaptureMetadataOutput *output = [[AVCaptureMetadataOutput alloc] init];
-[output setMetadataObjectTypes:@[AVMetadataObjectTypeQRCode]];
 [output setMetadataObjectsDelegate:self queue:dispatch_get_main_queue()];
 [session addOutput:output];
+[output setMetadataObjectTypes:@[AVMetadataObjectTypeQRCode]];
 
 [session startRunning];
 ~~~


### PR DESCRIPTION
It is only hinted at in the documentation, but you cannot set `metadataObjectTypes` until the `AVCaptureMetaDataOutput` is associated with a session.

From the docs on [`metadataObjectTypes`](https://developer.apple.com/library/IOs/documentation/AVFoundation/Reference/AVCaptureMetadataOutput/Reference/Reference.html#//apple_ref/occ/instp/AVCaptureMetadataOutput/metadataObjectTypes):

> When assigning a new array to this property, each of the type strings must be present in the array returned by the availableMetadataObjectTypes property; otherwise, the receiver raises an NSException.

and from the docs on [`availableMetadataObjectTypes`](https://developer.apple.com/library/IOs/documentation/AVFoundation/Reference/AVCaptureMetadataOutput/Reference/Reference.html#//apple_ref/occ/instp/AVCaptureMetadataOutput/availableMetadataObjectTypes):

> The available types are dependent on the capabilities of the AVCaptureInputPort to which the receiver’s connection is attached.

I was running the code as-is, and getting exceptions. This Stack Overflow answer http://stackoverflow.com/a/18995305/196358 suggested adding the AVCaptureMetaDataOutput to a session before assigning the metadataObjectTypes, which completely fixed the issue for me.
