### PR TITLE
Wrong type in file listing example

### DIFF
--- a/2013-11-18-nsfilemanager.md
+++ b/2013-11-18-nsfilemanager.md
@@ -36,7 +36,7 @@ NSArray *contents = [fileManager contentsOfDirectoryAtURL:bundleURL
                                                     error:nil];
 
 NSPredicate *predicate = [NSPredicate predicateWithFormat:@"pathExtension ENDSWITH '.png'"];
-for (NSString *path in [contents filteredArrayUsingPredicate:predicate]) {
+for (NSURL *fileURL in [contents filteredArrayUsingPredicate:predicate]) {
     // Enumerate each .png file in directory
 }
 ~~~


### PR DESCRIPTION
contentsOfDirectoryAtURL:includingPropertiesForKeys:options:error:
returns an array of NSURLs not NSString
