### PR TITLE
Remove @dynamic from sample implementation

### DIFF
--- a/2014-02-10-associated-objects.md
+++ b/2014-02-10-associated-objects.md
@@ -38,7 +38,6 @@ Why is this useful? It allows developers to **add custom properties to existing 
 
 ~~~{objective-c}
 @implementation NSObject (AssociatedObject)
-@dynamic associatedObject;
 
 - (void)setAssociatedObject:(id)object {
      objc_setAssociatedObject(self, @selector(associatedObject), object, OBJC_ASSOCIATION_RETAIN_NONATOMIC);


### PR DESCRIPTION
The `@dynamic` keyword indicates that the accessors will be provided dynamically at runtime, but the sample code already provides them at compile time. See:
https://developer.apple.com/library/mac/documentation/cocoa/conceptual/ObjCRuntimeGuide/Articles/ocrtDynamicResolution.html
