### PR TITLE
Fix list format characters

### DIFF
--- a/2014-03-24-nsurl.md
+++ b/2014-03-24-nsurl.md
@@ -108,26 +108,26 @@ NSURL *baseURL = [NSURL URLWithString:@"http://example.com/v1/"];
 
 `NSURL` provides accessor methods for each of the URL components as defined by [RFC 2396](http://www.ietf.org/rfc/rfc2396.txt):
 
-– `absoluteString`
-– `absoluteURL`
-– `baseURL`
-– `fileSystemRepresentation`
-– `fragment`
-– `host`
-– `lastPathComponent`
-– `parameterString`
-– `password`
-– `path`
-– `pathComponents`
-– `pathExtension`
-– `port`
-– `query`
-– `relativePath`
-– `relativeString`
-– `resourceSpecifier`
-– `scheme`
-– `standardizedURL`
-– `user`
+- `absoluteString`
+- `absoluteURL`
+- `baseURL`
+- `fileSystemRepresentation`
+- `fragment`
+- `host`
+- `lastPathComponent`
+- `parameterString`
+- `password`
+- `path`
+- `pathComponents`
+- `pathExtension`
+- `port`
+- `query`
+- `relativePath`
+- `relativeString`
+- `resourceSpecifier`
+- `scheme`
+- `standardizedURL`
+- `user`
 
 The documentation and examples found in [`NSURL`'s documentation](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSURL_Class/Reference/Reference.html) are a great way to familiarize yourself with all of the different components.
 


### PR DESCRIPTION
The list was using the character `-` instead of the character `-`. This allows the list to be property displayed when rendered from markdown.
