### PR TITLE
Update GHUnit repo URL

### DIFF
--- a/2013-05-27-unit-testing.md
+++ b/2013-05-27-unit-testing.md
@@ -133,9 +133,9 @@ Here's a list of some of the most useful open source libraries for unit testing:
   </thead>
   <tbody>
     <tr>
-      <td><a href="https://github.com/gabriel/gh-unit/">GHUnit</a></td>
+      <td><a href="https://github.com/gh-unit/gh-unit/">GHUnit</a></td>
       <td><a href="https://github.com/gabriel">Gabriel Handford</a></td>
-      <td><iframe src="http://ghbtns.com/github-btn.html?user=gabriel&repo=gh-unit&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="106" height="20"></iframe></td>
+      <td><iframe src="http://ghbtns.com/github-btn.html?user=gh-unit&repo=gh-unit&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="106" height="20"></iframe></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Weeeell, it looks like BDD frameworks all want a dedicated GitHub organization now. :necktie:
