### PR TITLE
fix the wrong word for zh-Hans

### DIFF
--- a/2013-02-18-reactivecocoa.md
+++ b/2013-02-18-reactivecocoa.md
@@ -143,7 +143,7 @@ Objective-C在C的核心上吸收了Smalltalk的思想建立而成，但哲学�
 
 `@protocol` 是对C++多重继承的拒绝，顺应抽象数据的类型范式是对Java `Interface`的吸收。Objective-C 2.0引入了`@property / @synthesize`则灵感来自C#的 `get; set;` 方法对getter和setter的速记（就语法上来说，这也是NeXTSETP强硬路线坚持者经常辩论的一点）。Block给这门语言带来了函数式编程的好处，可以使用Grand Central Dispatch——来自Fortran / C / C++ standard [OpenMP](http://en.wikipedia.org/wiki/OpenMP)思想而成的基于队列的并发API。下标和对象字面量都是像Ruby、Javascript这样的脚本语言的标准特性，如今也由一个Clang插件被带入了Objective-C的世界里。
 
-ReactiveCocoa则给Objective-C带来了函数响应式编程的健康药剂。它本身也是首C#的[Rx library](http://msdn.microsoft.com/en-us/data/gg577609.aspx)、[Clojure](http://en.wikipedia.org/wiki/Clojure)和[Elm][2]的影响才发展而成。
+ReactiveCocoa则给Objective-C带来了函数响应式编程的健康药剂。它本身也是受C#的[Rx library](http://msdn.microsoft.com/en-us/data/gg577609.aspx)、[Clojure](http://en.wikipedia.org/wiki/Clojure)和[Elm][2]的影响发展而成。
 
 好的点子会传染。ReactiveCocoa就是一种警示，提醒人们好的点子也可以从看似不太可能的地方传播过来，这样的新鲜思想对解决类似的问题也会有完全不同的方法呢。
 


### PR DESCRIPTION
Hi, Mattt!
In the 2013-02-18-reactivecocoa file for zh-Hans branch I found the wrong word, so I fix the wrong word for it. Please merge it, thx!
