### PR TITLE
Fixed Swift syntax for NSStream in iOS 8 article

### DIFF
--- a/2014-06-09-ios8.md
+++ b/2014-06-09-ios8.md
@@ -181,13 +181,13 @@ NSHipster will be covering a lot more about HealthKit in future editions, so sta
 In many ways, WWDC 2014 was the year that Apple _fixed their shit_. Small things, like adding the missing `NSStream` initializer for creating a bound stream pair (without resorting to awkwardly-bridged `CFStreamCreatePairWithSocketToHost` call). Behold: `+[NSStream getStreamsToHostWithName:port:inputStream:outputStream:]`
 
 ~~~{javascript}
-var inputStream: NSInputStream
-var outputStream: NSOutputStream
+var inputStream: NSInputStream?
+var outputStream: NSOutputStream?
 
-NSStream.getStreamsToHostWithName(hostname: "nshipster.com",
-                                      port: 5432,
-                               inputStream: &inputStream,
-                              outputStream: &outputStream)
+NSStream.getStreamsToHostWithName("nshipster.com",
+                            port: 5432,
+                     inputStream: &inputStream,
+                    outputStream: &outputStream)
 ~~~
 
 ## NSString -localizedCaseInsensitiveContainsString


### PR DESCRIPTION
Hi Mattt, looks like there's a small syntax error regarding optionals, and an extra parameter name in the iOS 8 article.

http://stackoverflow.com/questions/24461520/swift-cannot-convert-the-expressions-type-void-to-type-string
