### PR TITLE
Become first reponder before creating UIMenuController

### DIFF
--- a/2013-07-22-uimenucontroller.md
+++ b/2013-07-22-uimenucontroller.md
@@ -63,11 +63,10 @@ This may be due to how cumbersome it is to implement. Let's look at a simple imp
 #pragma mark - UIGestureRecognizer
 
 - (void)handleLongPressGesture:(UIGestureRecognizer *)recognizer  {
+	[recognizer.view becomeFirstResponder];
 	UIMenuController *menuController = [UIMenuController sharedMenuController];
     [menuController setTargetRect:recognizer.view.frame inView:recognizer.view.superview];
     [menuController setMenuVisible:YES animated:YES];
-
-    [recognizer.view becomeFirstResponder];
 }
 ~~~
 


### PR DESCRIPTION
When I was working with this I needed to have `becomeFirstResponder` first, without it the menu wouldn't appear till the second activation of the gesture recognizer.
