### PR TITLE
Replace references to CFAbsoluteTimeGetCurrent with CACurrentMediaTime

### DIFF
--- a/2014-05-19-benchmarking.md
+++ b/2014-05-19-benchmarking.md
@@ -38,7 +38,7 @@ In the case of programming, there are generally two kinds of questions to be ask
 
 Because the underlying factors of everything from the operating system down to the metal itself are extremely variable, performance should be measured across a large number of trials. For most applications, something on the order of 10<sup>5</sup> to 10<sup>8</sup> samples should be acceptable.
 
-### First Pass: CFAbsoluteTimeGetCurrent
+### First Pass: CACurrentMediaTime
 
 For this example, let's take a look at the performance characteristics of adding an object to a mutable array.
 
@@ -128,7 +128,7 @@ uint64_t t = dispatch_benchmark(iterations, ^{
 NSLog(@"[[NSMutableArray array] addObject:] Avg. Runtime: %llu ns", t);
 ```
 
-Ahhh, much better. Nanoseconds are a suitably precise time unit, and `dispatch_benchmark` has a much nicer syntax than manually looping and calling `CFAbsoluteTimeGetCurrent()`.
+Ahhh, much better. Nanoseconds are a suitably precise time unit, and `dispatch_benchmark` has a much nicer syntax than manually looping and calling `CACurrentMediaTime()`.
 
 ### NSMutableArray array vs. arrayWithCapacity:... FIGHT!
 


### PR DESCRIPTION
http://nshipster.com/benchmarking/

seems to have been written first with CFAbsoluteTimeGetCurrent but later had that call replaced with CACurrentMediaTime in the example. There are still lingering references to CFAbsoluteTimeGetCurrent that should be replaced with CACurrentMediaTime.
