### PR TITLE
No need for dependency graph to be in one queue

### DIFF
--- a/2014-07-14-nsoperation.md
+++ b/2014-07-14-nsoperation.md
@@ -154,7 +154,7 @@ operationQueue.addOperations([networkingOperation, resizingOperation], waitUntil
 
 An operation will not be started until all of its dependencies return `true` for `finished`.
 
-It's important to add all of the operations involved in a dependency graph to the same operation queue, lest there be a gap somewhere along the way. Also, make sure not to accidentally create a dependency cycle, such that A depends on B, and B depends on A, for example. This will create deadlock and sadness.
+Make sure not to accidentally create a dependency cycle, such that A depends on B, and B depends on A, for example. This will create deadlock and sadness.
 
 ## `completionBlock`
 


### PR DESCRIPTION
From https://developer.apple.com/library/ios/documentation/General/Conceptual/ConcurrencyProgrammingGuide/OperationObjects/OperationObjects.html (look for “Configuring Interoperation Dependencies”):

> Dependencies are also not limited to operations in the same queue. Operation objects manage their own dependencies and so it is perfectly acceptable to create dependencies between operations and add them all to different queues.

I have to admit that I have used such behaviour only once some time ago (producers-consumers situation, and I need to keep them under different concurrency constraints), so maybe you have included that warning for some reason I don’t know.
