### PR TITLE
Objective-C object subscripting corrections

### DIFF
--- a/2013-06-17-object-subscripting.md
+++ b/2013-06-17-object-subscripting.md
@@ -57,21 +57,11 @@ Where this really becomes interesting is when you extend your own classes with s
 
 ### Custom Indexed Subscripting
 
-To add custom-indexed subscripting support to your class, simply declare and implement the following methods:
-
-~~~{objective-c}
-- (id)objectAtIndexedSubscript:(NSUInteger)idx;
-- (void)setObject:(id)obj atIndexedSubscript:(NSUInteger)idx;
-~~~
+To add custom-indexed subscript reading support to your class, simply declare and implement `objectAtIndexedSubscript:`, where the parameter is of any integral type (such as `char`, `int`, or `NSUInteger`) and the return type is an Objective-C object pointer type. For indexed subscript writing, implement `setObject:atIndexedSubscript:`, where the first parameter is of Objective-C object pointer type, the second of integral type, and the return type is `void`.
 
 ### Custom Keyed Subscripting
 
-Similarly, custom-keyed subscripting can be added to your class by declaring and implementing these methods:
-
-~~~{objective-c}
-- (id)objectForKeyedSubscript:(id <NSCopying>)key;
-- (void)setObject:(id)obj forKeyedSubscript:(id <NSCopying>)key;
-~~~
+Similarly, custom-keyed subscripting can be added to your class by declaring and implementing `objectForKeyedSubscript:` and `setObject:forKeyedSubscript:`, where the subscript parameters are of Objective-C object pointer type.
 
 ## Custom Subscripting as DSL
 

--- a/2013-06-17-object-subscripting.md
+++ b/2013-06-17-object-subscripting.md
@@ -8,7 +8,11 @@ Xcode 4.4 quietly introduced a syntactic revolution to Objective-C. Like all rev
 
 > For the uninitiated, [Clang](http://clang.llvm.org/index.html) is the open source C language family front end to the [LLVM](http://www.llvm.org) compiler. Clang is responsible for all of the killer language features in Objective-C going back a few years, such as "Build & Analyze", ARC, blocks, and a nearly 3× performance boost when compiling over GCC.
 
-Clang 3.1 added three features to Objective-C whose aesthetic & cosmetic impact is comparable to the changes brought about in Objective-C 2.0: __`NSNumber` Literals__, __Collection Literals__, and __Object Subscripting__.
+Clang 3.1 added three features to Objective-C whose aesthetic & cosmetic impact is comparable to the changes brought about in Objective-C 2.0: [`NSNumber` Literals][num], [Collection Literals][col], and [Object Subscripting][sub].
+
+[num]: http://clang.llvm.org/docs/ObjectiveCLiterals.html#nsnumber-literals
+[col]: http://clang.llvm.org/docs/ObjectiveCLiterals.html#container-literals
+[sub]: http://clang.llvm.org/docs/ObjectiveCLiterals.html#object-subscripting
 
 In a single Xcode release, Objective-C went from this:
 

--- a/2013-08-19-nshashtable-and-nsmaptable.md
+++ b/2013-08-19-nshashtable-and-nsmaptable.md
@@ -74,18 +74,23 @@ Equal to `NSPointerFunctionsObjectPointerPersonality`.
 
 ### Subscripting
 
-After looking at a few code examples, a clever NSHipster may have thought "why aren't we using [object subscripting](http://nshipster.com/object-subscripting/)?". A particularly enterprising NSHipster may even have gotten a few lines of code into implementing a subscripting category for `NSMapTable`!
-
-So why doesn't `NSMapTable` implement subscripting? Take a look at these method signatures:
+`NSMapTable` does not implement [object subscripting](http://nshipster.com/object-subscripting/), but it can be trivially added in a category:
 
 ~~~{objective-c}
-- (id)objectForKeyedSubscript:(id <NSCopying>)key;
-- (void)setObject:(id)obj forKeyedSubscript:(id <NSCopying>)key;
+@implementation NSMapTable (NSHipsterSubscripting)
+
+- (id)objectForKeyedSubscript:(id)key
+{
+	return [self objectForKey:key];
+}
+
+- (void)setObject:(id)obj forKeyedSubscript:(id)key
+{
+	[self setObject:obj forKey:key];
+}
+
+@end
 ~~~
-
-Notice that the `key` argument is of type `<NSCopying>`. This is great for `NSDictionary` `NSMutableDictionary`, but we can't make that assumption for `NSMapTable`. And so we arrive at an impasse: with an `id <NSCopying>` type, we can't implement for `NSMapTable`, however if object subscripting methods were to drop the `<NSCopying>` constraint, then we would miss out on the compiler check in `NSMutableDictionary` `-setObject:forKeyedSubscript:`.
-
-So it goes. Honestly, in a situation where `NSMapTable` is merited, syntactic sugar is probably the least of one's concerns.
 
 ---
 


### PR DESCRIPTION
I expect these changes need editing for consistent style and tone, but the existing articles are incorrect. Clang might have changed since the original articles were written.

Indexed subscripts may be of any integral type; the `NSUInteger` requirement is imposed by `NSArray`, not the compiler. Similarly, keyed subscripts may be of any Objective-C object pointer type, and `NSCopying` is only required by `NSDictionary` to match its existing API and provide compiler warnings when using subscripting.

For example, you could implement

	- (NSData *)objectForKeyedSubscript:(NSURL *)key

to get type checking on the parameter and return types when using

	NSData *fileData = myObject[myURL]
