### PR TITLE
moved destroyAction from Alert View example to Action Sheet example

### DIFF
--- a/2014-09-30-uialertcontroller.md
+++ b/2014-09-30-uialertcontroller.md
@@ -71,11 +71,6 @@ let cancelAction = UIAlertAction(title: "Cancel", style: .Cancel) { (action) in
 }
 alertController.addAction(cancelAction)
 
-let destroyAction = UIAlertAction(title: "Destroy", style: .Destructive) { (action) in
-    println(action)
-}
-alertController.addAction(destroyAction)
-
 let OKAction = UIAlertAction(title: "OK", style: .Default) { (action) in
     // ...
 }
@@ -122,6 +117,11 @@ let OKAction = UIAlertAction(title: "OK", style: .Default) { (action) in
     // ...
 }
 alertController.addAction(OKAction)
+
+let destroyAction = UIAlertAction(title: "Destroy", style: .Destructive) { (action) in
+    println(action)
+}
+alertController.addAction(destroyAction)
 
 self.presentViewController(alertController, animated: true) {
     // ...


### PR DESCRIPTION
I noticed that the Alert View example has a destroyAction that should be on the Action Sheet example so I moved that part. Hope I got it right :-)
