### PR TITLE
AVMakeRectWithAspectRatioInsideRect returns CGRect

### DIFF
--- a/2014-09-15-image-resizing.md
+++ b/2014-09-15-image-resizing.md
@@ -48,7 +48,7 @@ It's often useful to scale the original size in such a way that fits within a re
 
 ~~~{swift}
 import AVFoundation
-let size = AVMakeRectWithAspectRatioInsideRect(image.size, imageView.bounds)
+let rect = AVMakeRectWithAspectRatioInsideRect(image.size, imageView.bounds)
 ~~~
 
 ## Resizing Images


### PR DESCRIPTION
`AVMakeRectWithAspectRatioInsideRect` returns a `CGRect` rather than `CGSize`. I changed the name of the variable to avoid confusion.
