### PR TITLE
Changed .toRaw() to property .rawValue in NSLinguisticTagger article

### DIFF
--- a/2012-10-22-nslinguistictagger.md
+++ b/2012-10-22-nslinguistictagger.md
@@ -34,7 +34,7 @@ tagger.string = question;
 let question = "What is the weather in San Francisco?"
 let options: NSLinguisticTaggerOptions = .OmitWhitespace | .OmitPunctuation | .JoinNames
 let schemes = NSLinguisticTagger.availableTagSchemesForLanguage("en")
-let tagger = NSLinguisticTagger(tagSchemes: schemes, options: Int(options.toRaw()))
+let tagger = NSLinguisticTagger(tagSchemes: schemes, options: Int(options.rawValue))
 tagger.string = question
 tagger.enumerateTagsInRange(NSMakeRange(0, (question as NSString).length), scheme: NSLinguisticTagSchemeNameTypeOrLexicalClass, options: options) { (tag, tokenRange, sentenceRange, _) in
     let token = (question as NSString).substringWithRange(tokenRange)


### PR DESCRIPTION
The method .fromRaw() has been replaced with the property .rawValue. Submitting this pull request to reflect that change.
