### PR TITLE
Mention Swift interoperability in NS_ENUM/NS_OPTIONS article

### DIFF
--- a/2012-11-19-ns_enum-ns_options.md
+++ b/2012-11-19-ns_enum-ns_options.md
@@ -24,7 +24,7 @@ And on that note, this week's topic has to do with two simple-but-handy macros: 
 
 ---
 
-Introduced in Foundation with iOS 6 / OS X Mountain Lion, the `NS_ENUM` and `NS_OPTIONS` macros are the new, preferred way to declare `enum` types.
+Introduced in Foundation with iOS 6 / OS X Mountain Lion, the `NS_ENUM` and `NS_OPTIONS` macros are the new, preferred way to declare `enum` types. `enum`s that are declared in Objective-C using `NS_ENUM` and `NS_OPTIONS` are imported into Swift natively.
 
 > If you'd like to use either macro when targeting a previous version of iOS or OS X, you can simply inline like so:
 


### PR DESCRIPTION
Now that Swift has been publicly released, it is the most compelling reason to use NS_ENUM and NS_OPTIONS in Objective-C code.

The excellent article on these two macros was written well before Swift, so it did not mention this at all. I added a single sentence to address this; perhaps even more info would be useful to add as well. ([Apple's docs](https://developer.apple.com/library/ios/documentation/Swift/Conceptual/BuildingCocoaApps/InteractingWithCAPIs.html) discuss this in more detail.) But this is at least a start!