### PR TITLE
Added additional comments for clarification on swizzling class methods

### DIFF
--- a/2014-02-17-method-swizzling.md
+++ b/2014-02-17-method-swizzling.md
@@ -48,6 +48,10 @@ Fortunately, there is another way: **method swizzling** from a category. Here's 
         Method originalMethod = class_getInstanceMethod(class, originalSelector);
         Method swizzledMethod = class_getInstanceMethod(class, swizzledSelector);
 
+        // When swizzling a class method, use the following:
+        // Method originalMethod = class_getClassMethod(class, originalSelector);
+        // Method swizzledMethod = class_getClassMethod(class, swizzledSelector);
+
         BOOL didAddMethod =
             class_addMethod(class,
                 originalSelector,


### PR DESCRIPTION
There's a comment above my addition clarifying how to get the correct Class reference when swizzling a class method (as opposed to an instance). Just adding some further clarification on the objc Method resolving calls.