### PR TITLE
Minor grammatical fixes

### DIFF
--- a/2015-01-26-swift-objc-runtime.md
+++ b/2015-01-26-swift-objc-runtime.md
@@ -14,7 +14,7 @@ This week we take a new, Swift-focused look at two runtime techniques covered on
 
 ## Associated Objects
 
-Swift extensions allow for great flexibility in adding to the functionality of existing Cocoa classes, but they're limited in the same way as their Objective-C brethren, categories. Namely, you can't add a property to an existing class via extension.
+Swift extensions allow for great flexibility in adding to the functionality of existing Cocoa classes, but they're limited in the same way as their Objective-C brethren, categories. Namely, you can't add a property to an existing class via an extension.
 
 Happily, Objective-C *associated objects* come to the rescue. For example, to add a `descriptiveName` property to all the view controllers in a project, we simply add a computed property using `objc_get/setAssociatedObject()` in the backing `get` and `set` blocks:
 

--- a/2015-01-26-swift-objc-runtime.md
+++ b/2015-01-26-swift-objc-runtime.md
@@ -14,7 +14,7 @@ This week we take a new, Swift-focused look at two runtime techniques covered on
 
 ## Associated Objects
 
-Swift extensions allow for great flexibility in adding to the functionality of existing Cocoa classes, but they're limited in the same way as their Objective-C brethren, the category. Namely, you can't add a property to an existing class via extension.
+Swift extensions allow for great flexibility in adding to the functionality of existing Cocoa classes, but they're limited in the same way as their Objective-C brethren, categories. Namely, you can't add a property to an existing class via extension.
 
 Happily, Objective-C *associated objects* come to the rescue. For example, to add a `descriptiveName` property to all the view controllers in a project, we simply add a computed property using `objc_get/setAssociatedObject()` in the backing `get` and `set` blocks:
 


### PR DESCRIPTION
- Fixed singular/plural disagreement in "their Objective-C brethren, *the category*"
- Added an article: "you can't add a property to an existing class via *an* extension."