### PR TITLE
Use static keyword instead of class for protocols

### DIFF
--- a/2015-01-19-javascriptcore.md
+++ b/2015-01-19-javascriptcore.md
@@ -183,7 +183,7 @@ Our `Person` class implements the `PersonJSExports` protocol, which specifies wh
     func getFullName() -> String
 
     /// create and return a new Person instance with `firstName` and `lastName`
-    class func createWithFirstName(firstName: String, lastName: String) -> Person
+    static func createWithFirstName(firstName: String, lastName: String) -> Person
 }
 
 // Custom class must inherit from `NSObject`


### PR DESCRIPTION
Compile error if you use "class func" instead of "static func" in a protocols.