### PR TITLE
Fix presenting UIMenuController multiple times

### DIFF
--- a/2013-07-22-uimenucontroller.md
+++ b/2013-07-22-uimenucontroller.md
@@ -62,10 +62,12 @@ This may be due to how cumbersome it is to implement. Let's look at a simple imp
 #pragma mark - UIGestureRecognizer
 
 - (void)handleLongPressGesture:(UIGestureRecognizer *)recognizer  {
-	[recognizer.view becomeFirstResponder];
-	UIMenuController *menuController = [UIMenuController sharedMenuController];
-    [menuController setTargetRect:recognizer.view.frame inView:recognizer.view.superview];
-    [menuController setMenuVisible:YES animated:YES];
+    if (recognizer.state == UIGestureRecognizerStateRecognized) {
+        [recognizer.view becomeFirstResponder];
+        UIMenuController *menuController = [UIMenuController sharedMenuController];
+        [menuController setTargetRect:recognizer.view.frame inView:recognizer.view.superview];
+        [menuController setMenuVisible:YES animated:YES];
+    }
 }
 ~~~
 


### PR DESCRIPTION
Since `-handleLongPressGesture:` is called each time the gesture recognizer's `state` changes, the `UIMenuController` ends up being presented multiple times. The result of presenting the menu controller multiple times is simply a visual glitch, so not a huge deal, but this change fixes it.

Also, I'm sorry if I guessed wrong on tabs vs. spaces. It seems like both were being used, so I guessed spaces.