### PR TITLE
Fixed example for localization

### DIFF
--- a/2015-06-22-ios9.md
+++ b/2015-06-22-ios9.md
@@ -206,8 +206,12 @@ shortFormatter.stringFromDate(now)
 fullFormatter.locale = NSLocale(localeIdentifier: "de_DE")
 shortFormatter.locale = NSLocale(localeIdentifier: "de_DE")
 
+// set the date formats again, because other languages use different formats
+fullFormatter.setLocalizedDateFormatFromTemplate("yyyyMMMMddhhmm")
+shortFormatter.setLocalizedDateFormatFromTemplate("yyMMMM")
+
 fullFormatter.stringFromDate(now)
-// "Juni 23, 2015, 4:56 nachm."
+// "23. Juni 2015, 4:56 nachm."
 shortFormatter.stringFromDate(now)
 // "Juni 15"
 ```


### PR DESCRIPTION
Just translating words isn't enough. The resulting strings are still not correctly localized, but that's a problem with `setLocalizedDateFormatFromTemplate` itself.

Correct would be `23. Juni 2015, 16:56`, but that would require changing the template from `yyyyMMMMddhhmm` to `yyyyMMMMddHHmm`.