### PR TITLE
Updates for NSOrderedSet, NSOperation, PHImageManager, NSRange, NSDateComponents, NSPredicate and Swift & the Objective-C Runtime

### DIFF
--- a/2012-07-31-nsdatecomponents.md
+++ b/2012-07-31-nsdatecomponents.md
@@ -4,7 +4,8 @@ author: Mattt Thompson
 category: Cocoa
 excerpt: "NSDateComponents serves an important role in Foundation's date and time APIs. By itself, it's nothing impressive—just a container for information about a date (its month, year, day of month, week of year, or whether that month is a leap month). However, combined with NSCalendar, NSDateComponents becomes a remarkably convenient interchange format for calendar calculations."
 status:
-    swift: 1.1
+    swift: 2.0
+    reviewed: September 19, 2015
 ---
 
 `NSDateComponents` serves an important role in Foundation's date and time APIs. By itself, it's nothing impressive—just a container for information about a date (its month, year, day of month, week of year, or whether that month is a leap month). However, combined with `NSCalendar`, `NSDateComponents` becomes a remarkably convenient interchange format for calendar calculations.
@@ -18,8 +19,8 @@ Whereas dates represent a particular moment in time, date components depend on w
 ~~~{swift}
 let calendar = NSCalendar.currentCalendar()
 let date = NSDate()
-let components = calendar.components(.CalendarUnitMonth | .CalendarUnitDay, fromDate: date)
-~~~ 
+let components = calendar.components([.Month, .Day], fromDate: date)
+~~~
 
 ~~~{objective-c}
 NSCalendar *calendar = [NSCalendar currentCalendar];
@@ -30,21 +31,21 @@ NSDate *date = [NSDate date];
 The `components` parameter is a [bitmask](http://en.wikipedia.org/wiki/Bitmask) of the date component values to retrieve, with many to choose from:
 
 ~~~{swift}
-.CalendarUnitEra
-.CalendarUnitYear
-.CalendarUnitMonth
-.CalendarUnitDay
-.CalendarUnitHour
-.CalendarUnitMinute
-.CalendarUnitSecond
-.CalendarUnitWeekday
-.CalendarUnitWeekdayOrdinal
-.CalendarUnitQuarter
-.CalendarUnitWeekOfMonth
-.CalendarUnitWeekOfYear
-.CalendarUnitYearForWeekOfYear
-.CalendarUnitCalendar
-.CalendarUnitTimeZone
+NSCalendarUnit.Era
+NSCalendarUnit.Year
+NSCalendarUnit.Month
+NSCalendarUnit.Day
+NSCalendarUnit.Hour
+NSCalendarUnit.Minute
+NSCalendarUnit.Second
+NSCalendarUnit.Weekday
+NSCalendarUnit.WeekdayOrdinal
+NSCalendarUnit.Quarter
+NSCalendarUnit.WeekOfMonth
+NSCalendarUnit.WeekOfYear
+NSCalendarUnit.YearForWeekOfYear
+NSCalendarUnit.Calendar
+NSCalendarUnit.TimeZone
 ~~~
 
 ~~~{objective-c}
@@ -79,7 +80,7 @@ let components = NSDateComponents()
 components.weekOfYear = 1
 components.hour = 12
 
-println("1 week and 12 hours from now: \(calendar.dateByAddingComponents(components, toDate: date, options: nil))")
+print("1 week and 12 hours from now: \(calendar.dateByAddingComponents(components, toDate: date, options: []))")
 ~~~
 
 ~~~{objective-c}
@@ -98,7 +99,7 @@ NSLog(@"1 week and twelve hours from now: %@", [calendar dateByAddingComponents:
 Perhaps the most powerful feature of `NSDateComponents`, however, is the ability to go the opposite direction—creating an `NSDate` object from components. `NSCalendar -dateFromComponents:` is the method used for this purpose:
 
 ~~~{swift}
-let calendar = NSCalendar(identifier: NSGregorianCalendar)
+let calendar = NSCalendar(identifier: NSCalendarIdentifierGregorian)
 
 let components = NSDateComponents()
 components.year = 1987
@@ -108,7 +109,7 @@ components.hour = 14
 components.minute = 20
 components.second = 0
 
-let date = calendar.dateFromComponents(components)
+let date = calendar?.dateFromComponents(components)
 ~~~
 
 ~~~{objective-c}

--- a/2012-11-26-nsorderedset.md
+++ b/2012-11-26-nsorderedset.md
@@ -5,7 +5,8 @@ category: Cocoa
 tags: nshipster
 excerpt: "Why isn't NSOrderedSet a subclass of NSSet? The answer may surprise you."
 status:
-    swift: 1.1
+    swift: 2.0
+    reviewed: September 15, 2015
 ---
 
 Here's a question: why isn't `NSOrderedSet` a subclass of `NSSet`?
@@ -27,8 +28,8 @@ As expertly demonstrated by [Tom Dalling](http://tomdalling.com) in [this Stack 
 To start, let's look at how `-mutableCopy` is supposed to work in a class cluster:
 
 ~~~{swift}
-let immutable: NSSet = NSSet()
-var mutable: NSMutableSet = immutable.mutableCopy() as NSMutableSet
+let immutable = NSSet()
+let mutable = immutable.mutableCopy() as! NSMutableSet
 
 mutable.isKindOfClass(NSSet.self) // true
 mutable.isKindOfClass(NSMutableSet.self) // true
@@ -47,8 +48,8 @@ Now let's suppose that `NSOrderedSet` was indeed a subclass of `NSSet`:
 ~~~{swift}
 // class NSOrderedSet: NSSet {...}
 
-let immutable: NSOrderedSet = NSOrderedSet()
-var mutable: NSMutableOrderedSet = immutable.mutableCopy() as NSMutableOrderedSet
+let immutable = NSOrderedSet()
+let mutable = immutable.mutableCopy() as! NSMutableOrderedSet
 
 mutable.isKindOfClass(NSSet.self) // true
 mutable.isKindOfClass(NSMutableSet.self) // false (!)
@@ -72,8 +73,8 @@ That's no good... since `NSMutableOrderedSet` couldn't be used as a method param
 // class NSOrderedSet: NSSet {...}
 // class NSMutableOrderedSet: NSMutableSet {...}
 
-let immutable: NSOrderedSet = NSOrderedSet()
-var mutable: NSMutableOrderedSet = immutable.mutableCopy() as NSMutableOrderedSet
+let immutable = NSOrderedSet()
+let mutable = immutable.mutableCopy() as! NSMutableOrderedSet
 
 mutable.isKindOfClass(NSSet.self) // true
 mutable.isKindOfClass(NSMutableSet.self) // true

--- a/2013-07-15-nspredicate.md
+++ b/2013-07-15-nspredicate.md
@@ -5,7 +5,8 @@ category: Cocoa
 tags: nshipster, popular
 excerpt: "NSPredicate is a Foundation class that specifies how data should be fetched or filtered. Its query language, which is like a cross between a SQL WHERE clause and a regular expression, provides an expressive, natural language interface to define logical conditions on which a collection is searched."
 status:
-    swift: 1.1
+    swift: 2.0
+    reviewed: September 19, 2015
 ---
 
 `NSPredicate` is a Foundation class that specifies how data should be fetched or filtered. Its query language, which is like a cross between a SQL `WHERE` clause and a regular expression, provides an expressive, natural language interface to define logical conditions on which a collection is searched.
@@ -244,7 +245,7 @@ Analyzing its class constructor provides a glimpse into the way `NSPredicate` fo
 ### `NSComparisonPredicate` Types
 
 ~~~{swift}
-enum NSPredicateOperatorType : UInt {
+public enum NSPredicateOperatorType : UInt {
     case LessThanPredicateOperatorType
     case LessThanOrEqualToPredicateOperatorType
     case GreaterThanPredicateOperatorType
@@ -296,7 +297,7 @@ Finally, if you just can't be bothered to learn the `NSPredicate` format syntax,
 
 ~~~{swift}
 let shortNamePredicate = NSPredicate { (evaluatedObject, _) in
-    return (evaluatedObject as Person).firstName.utf16Count <= 5
+    return (evaluatedObject as! Person).firstName.utf16.count <= 5
 }
 
 (people as NSArray).filteredArrayUsingPredicate(shortNamePredicate)

--- a/2014-01-13-nsrange.md
+++ b/2014-01-13-nsrange.md
@@ -4,7 +4,8 @@ author: Mattt Thompson
 category: Cocoa
 excerpt: "NSRange is one of the essential types of Foundation. Passed around and returned in methods throughout the framework, being well-versed in this struct has a range of benefits."
 status:
-    swift: t.b.c.
+    swift: 2.0
+    reviewed: September 15, 2015
 ---
 
 `NSRange` is one of the essential types of Foundation. Passed around and returned in methods throughout the framework, being well-versed in this struct has a range of benefits, which this week's article will help you locate.
@@ -14,6 +15,15 @@ status:
 Ranges are data types used to describe a contiguous interval of integers. They are most commonly used with strings, arrays, and similarly-ordered collections.
 
 For Objective-C programs, the Foundation type `NSRange` is used. In other languages, ranges are often encoded as a two-element array, containing the start and end indexes. In Foundation, `NSRange` instead encodes a range as struct containing the location and length. By command-clicking (`⌘-ʘ`) on the `NSRange` symbol in Xcode, we can jump directly to its declaration in `Foundation/NSRange.h`:
+
+~~~{swift}
+public struct _NSRange {
+    public var location: Int
+    public var length: Int
+    public init()
+    public init(location: Int, length: Int)
+}
+~~~
 
 ~~~{objective-c}
 typedef struct _NSRange {
@@ -35,6 +45,11 @@ Forgetting to subtract `1` for the end index in Javascript would result in an ou
 
 #### range.m
 
+~~~{swift}
+let string = "hello, world"
+let range = NSMakeRange(0, string.characters.count)
+~~~
+
 ~~~{objective-c}
 NSString *string = @"hello, world";
 NSRange range = NSMakeRange(0, [string length]);
@@ -46,16 +61,28 @@ NSRange range = NSMakeRange(0, [string length]);
 
 ### Strings
 
+~~~{swift}
+let string: NSString = "lorem ipsum dolor sit amet"
+let range = string.rangeOfString("ipsum") // {.location=6, .length=5}
+
+let substring = string.substringWithRange(range) // "ipsum"
+~~~
+
 ~~~{objective-c}
 NSString *string = @"lorem ipsum dolor sit amet";
-NSRange range = [string rangeOfString:@"ipsum"];
-// {.location=6, .length=5}
+NSRange range = [string rangeOfString:@"ipsum"]; // {.location=6, .length=5}
 
-NSString *substring = [string substringWithRange:range];
-// @"ipsum"
+NSString *substring = [string substringWithRange:range]; // @"ipsum"
 ~~~
 
 `NSString` does not have a method like `containsString:`. Instead, `rangeOfString:` can be used to check for an `NSNotFound` location value:
+
+~~~{swift}
+let input: NSString = ...
+if input.rangeOfString("keyword").location != NSNotFound {
+    // ...
+}
+~~~
 
 ~~~{objective-c}
 NSString *input = ...;
@@ -66,15 +93,24 @@ if ([input rangeOfString:@"keyword"].location != NSNotFound) {
 
 ### Arrays
 
+~~~{swift}
+let array: NSArray = ["a", "b", "c", "d"]
+let subArray = array.subarrayWithRange(NSMakeRange(1, 2)) // ["b", "c"]
+~~~
+
 ~~~{objective-c}
 NSArray *array = @[@"a", @"b", @"c", @"d"];
-NSArray *subarray = [array subarrayWithRange:NSMakeRange(1, 2)];
-// @[@"b", @"c"]
+NSArray *subArray = [array subarrayWithRange:NSMakeRange(1, 2)]; // @[@"b", @"c"]
 ~~~
 
 ### Index Sets
 
 [NSIndexSet](http://nshipster.com/nsindexset/) is a Foundation collection class that is similar to `NSRange`, with the notable exception of being able to support non-contiguous series. An `NSIndexSet` can be created from a range using the `indexSetWithIndexesInRange:` class constructor:
+
+~~~{swift}
+let range = NSMakeRange(0, 10)
+let indexSet = NSIndexSet(indexesInRange: range)
+~~~
 
 ~~~{objective-c}
 NSRange range = NSMakeRange(0, 10);
@@ -93,15 +129,25 @@ Because `NSRange` is not a class, creating and using instances is done through f
 
 > - `NSMakeRange`:  Creates a new NSRange from the specified values.
 
+~~~{swift}
+let array: NSArray = [1, 2, 3]
+let range = NSMakeRange(0, array.count) // {.location=0, .length=3}
+~~~
+
 ~~~{objective-c}
 NSArray *array = @[@1, @2, @3];
-NSRange range = NSMakeRange(0, [array count]);
-// {.location=0, .length=3}
+NSRange range = NSMakeRange(0, [array count]); // {.location=0, .length=3}
 ~~~
 
 ### Querying Information
 
 > - `NSEqualRanges`: Returns a Boolean value that indicates whether two given ranges are equal.
+
+~~~{swift}
+let range1 = NSMakeRange(0, 6)
+let range2 = NSMakeRange(2, 7)
+let equal = NSEqualRanges(range1, range2) // false
+~~~
 
 ~~~{objective-c}
 NSRange range1 = NSMakeRange(0, 6);
@@ -111,12 +157,22 @@ BOOL equal = NSEqualRanges(range1, range2); // NO
 
 > - `NSLocationInRange`:  Returns a Boolean value that indicates whether a specified position is in a given range.
 
+~~~{swift}
+let range = NSMakeRange(3, 4)
+let contained = NSLocationInRange(5, range) // true
+~~~
+
 ~~~{objective-c}
 NSRange range = NSMakeRange(3, 4);
 BOOL contained = NSLocationInRange(5, range); // YES
 ~~~
 
 > - `NSMaxRange`: Returns the sum of the location and length of the range.
+
+~~~{swift}
+let range = NSMakeRange(3, 4)
+let max = NSMaxRange(range) // 7
+~~~
 
 ~~~{objective-c}
 NSRange range = NSMakeRange(3, 4);
@@ -127,25 +183,40 @@ NSUInteger max = NSMaxRange(range); // 7
 
 > - `NSIntersectionRange`: Returns the intersection of the specified ranges. If the returned range’s length field is `0`, then the two ranges don’t intersect, and the value of the location field is undefined.
 
+~~~{swift}
+let range1 = NSMakeRange(0, 6)
+let range2 = NSMakeRange(2, 7)
+let intersectionRange = NSIntersectionRange(range1, range2) // {.location=2, .length=4}
+~~~
+
 ~~~{objective-c}
 NSRange range1 = NSMakeRange(0, 6);
 NSRange range2 = NSMakeRange(2, 7);
-NSRange intersectionRange = NSIntersectionRange(range1, range2);
-// {.location=2, .length=4}
+NSRange intersectionRange = NSIntersectionRange(range1, range2); // {.location=2, .length=4}
 ~~~
 
 > - `NSUnionRange`: Returns the union of the specified ranges. A range covering all indices in and between range1 and range2. If one range is completely contained in the other, the returned range is equal to the larger range.
 
+~~~{swift}
+let range1 = NSMakeRange(0, 6)
+let range2 = NSMakeRange(2, 7)
+let unionRange = NSUnionRange(range1, range2) // // {.location=0, .length=9}
+~~~
+
 ~~~{objective-c}
 NSRange range1 = NSMakeRange(0, 6);
 NSRange range2 = NSMakeRange(2, 7);
-NSRange unionRange = NSUnionRange(range1, range2);
-// {.location=0, .length=9}
+NSRange unionRange = NSUnionRange(range1, range2); // {.location=0, .length=9}
 ~~~
 
 ### Converting Between NSString * & NSRange
 
 > - `NSStringFromRange`: Returns a string representation of a range.
+
+~~~{swift}
+let range = NSMakeRange(3, 4)
+let string = NSStringFromRange(range) // "{3,4}"
+~~~
 
 ~~~{objective-c}
 NSRange range = NSMakeRange(3, 4);
@@ -154,21 +225,34 @@ NSString *string = NSStringFromRange(range); // @"{3,4}"
 
 > - `NSRangeFromString`: Returns a range from a textual representation.
 
+~~~{swift}
+let string = "{1,5}"
+let range = NSRangeFromString(string) // {.location=1, .length=5}
+~~~
+
 ~~~{objective-c}
 NSString *string = @"{1,5}";
-NSRange range = NSRangeFromString(string);
-// {.location=1, .length=5}
+NSRange range = NSRangeFromString(string); // {.location=1, .length=5}
 ~~~
 
 If the string passed into `NSRangeFromString` does not represent a valid range, it will return a range with its location and length set to `0`.
 
+~~~{swift}
+let string = "invalid"
+let range = NSRangeFromString(string) // {.location=0, .length=0}
+~~~
+
 ~~~{objective-c}
 NSString *string = @"invalid";
-NSRange range = NSRangeFromString(string);
-// {.location=0, .length=0}
+NSRange range = NSRangeFromString(string); // {.location=0, .length=0}
 ~~~
 
 While one might be tempted to use `NSStringFromRange` to box `NSRange` for inclusion within an `NSArray`, `NSValue +valueWithRange:` is the way to go:
+
+~~~{swift}
+let range = NSMakeRange(0, 3)
+let value = NSValue(range: range)
+~~~
 
 ~~~{objective-c}
 NSRange range = NSMakeRange(0, 3);
@@ -208,15 +292,35 @@ One oddity worth mentioning with `NSRange` is the existence of `NSRangePointer`.
 
 #### Foundation/NSRange.h
 
+~~~{swift}
+public typealias NSRangePointer = UnsafeMutablePointer<NSRange>
+~~~
+
 ~~~{objective-c}
 typedef NSRange *NSRangePointer;
 ~~~
 
 So. Without a definitive origin story, one would have to assume that this type was created by a well-meaning framework engineer who noted the confusion around `NSRange` being a struct and not a class. `NSRange *` is equivalent to `NSRangePointer`, though the latter can be found in out parameters for various methods throughout Foundation. `NSAttributedString`, for instance, has an `NSRangePointer` parameter for returning the effective range of an attribute at a particular index (since the attribute likely starts and ends before outside of the specified index):
 
+~~~{swift}
+let mutableAttributedString: NSMutableAttributedString = ...
+var range = NSRange()
+
+if let _ = mutableAttributedString.attribute(NSUnderlineStyleAttributeName,
+    atIndex: 0,
+    effectiveRange: &range)
+{
+    mutableAttributedString.addAttribute(NSForegroundColorAttributeName,
+        value: UIColor.blueColor(),
+        range: range
+    )
+}
+~~~
+
 ~~~{objective-c}
 NSMutableAttributedString *mutableAttributedString = ...;
 NSRange range;
+
 if ([mutableAttributedString attribute:NSUnderlineStyleAttributeName
                                atIndex:0
                         effectiveRange:&range])
@@ -231,6 +335,15 @@ if ([mutableAttributedString attribute:NSUnderlineStyleAttributeName
 ## CFRange
 
 One final caveat: Core Foundation also defines a `CFRange` type, which differs from `NSRange` in using `CFIndex` types for its members, and having only the function `CFRangeMake`:
+
+~~~{swift}
+public struct CFRange {
+    public var location: CFIndex
+    public var length: CFIndex
+    public init()
+    public init(location: CFIndex, length: CFIndex)
+}
+~~~
 
 ~~~{objective-c}
 typedef struct {

--- a/2014-07-14-nsoperation.md
+++ b/2014-07-14-nsoperation.md
@@ -5,7 +5,8 @@ category: Cocoa
 tags: nshipster
 excerpt: "In life, there's always work to be done. Every day brings with it a steady stream of tasks and chores to fill the working hours of our existence. Productivity is, as in life as it is in programming, a matter of scheduling and prioritizing and multi-tasking work in order to keep up appearances."
 status:
-    swift: 1.2
+    swift: 2.0
+    reviewed: September 15, 2015
 ---
 
 In life, there's always work to be done. Every day brings with it a steady stream of tasks and chores to fill the working hours of our existence.
@@ -66,7 +67,7 @@ All operations may not be equally important. Setting the `queuePriority` propert
 ### NSOperationQueuePriority
 
 ~~~{swift}
-enum NSOperationQueuePriority : Int {
+public enum NSOperationQueuePriority : Int {
     case VeryLow
     case Low
     case Normal
@@ -75,13 +76,13 @@ enum NSOperationQueuePriority : Int {
 }
 ~~~
 ~~~{objective-c}
-typedef enum : NSInteger {
-   NSOperationQueuePriorityVeryLow = -8,
-   NSOperationQueuePriorityLow = -4,
-   NSOperationQueuePriorityNormal = 0,
-   NSOperationQueuePriorityHigh = 4,
-   NSOperationQueuePriorityVeryHigh = 8
-} NSOperationQueuePriority;
+typedef NS_ENUM(NSInteger, NSOperationQueuePriority) {
+    NSOperationQueuePriorityVeryLow = -8L,
+    NSOperationQueuePriorityLow = -4L,
+    NSOperationQueuePriorityNormal = 0,
+    NSOperationQueuePriorityHigh = 4,
+    NSOperationQueuePriorityVeryHigh = 8
+};
 ~~~
 
 ## Quality of Service
@@ -99,7 +100,8 @@ The following enumerated values are used to denote the nature and urgency of an 
 ### NSQualityOfService
 
 ~~~{swift}
-enum NSQualityOfService : Int {
+@available(iOS 8.0, OSX 10.10, *)
+public enum NSQualityOfService : Int {    
     case UserInteractive
     case UserInitiated
     case Utility
@@ -108,13 +110,13 @@ enum NSQualityOfService : Int {
 }
 ~~~
 ~~~{objective-c}
-typedef enum : NSInteger {
-    NSQualityOfServiceUserInteractive = 0x21,
-    NSQualityOfServiceUserInitiated = 0x19,
-    NSQualityOfServiceUtility = 0x11,
+typedef NS_ENUM(NSInteger, NSQualityOfService) {
+    NSQualityOfServiceUserInteractive = 0x21,    
+    NSQualityOfServiceUserInitiated = 0x19,    
+    NSQualityOfServiceUtility = 0x11,    
     NSQualityOfServiceBackground = 0x09,
     NSQualityOfServiceDefault = -1
-} NSQualityOfService;
+} NS_ENUM_AVAILABLE(10_10, 8_0);
 ~~~
 
 - `.UserInteractive`:UserInteractive QoS is used for work directly involved in providing an interactive UI such as processing events or drawing to the screen.
@@ -124,7 +126,7 @@ typedef enum : NSInteger {
 - `.Default`: Default QoS indicates the absence of QoS information.  Whenever possible QoS information will be inferred from other sources.  If such inference is not possible, a QoS between UserInitiated and Utility will be used.
 
 ~~~{swift}
-let backgroundOperation: NSOperation = NSOperation()
+let backgroundOperation = NSOperation()
 backgroundOperation.queuePriority = .Low
 backgroundOperation.qualityOfService = .Background
 
@@ -154,8 +156,8 @@ For example, to describe the process of downloading and resizing an image from a
 Expressed in code:
 
 ~~~{swift}
-let networkingOperation : NSOperation = ...
-let resizingOperation : NSOperation = ...
+let networkingOperation: NSOperation = ...
+let resizingOperation: NSOperation = ...
 resizingOperation.addDependency(networkingOperation)
 
 let operationQueue = NSOperationQueue.mainQueue()
@@ -183,7 +185,7 @@ When an `NSOperation` finishes, it will execute its `completionBlock` exactly on
 ~~~{swift}
 let operation = NSOperation()
 operation.completionBlock = {
-    println("Completed")
+    print("Completed")
 }
 
 NSOperationQueue.mainQueue().addOperation(operation)

--- a/2015-01-26-swift-objc-runtime.md
+++ b/2015-01-26-swift-objc-runtime.md
@@ -31,13 +31,14 @@ extension UIViewController {
         get {
             return objc_getAssociatedObject(self, &AssociatedKeys.DescriptiveName) as? String
         }
+
         set {
             if let newValue = newValue {
                 objc_setAssociatedObject(
                     self,
                     &AssociatedKeys.DescriptiveName,
                     newValue as NSString?,
-                    UInt(OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+                    .OBJC_ASSOCIATION_RETAIN_NONATOMIC
                 )
             }
         }
@@ -61,7 +62,7 @@ extension UIViewController {
             static var token: dispatch_once_t = 0
         }
 
-        // make sure this isn't a subclass        
+        // make sure this isn't a subclass
         if self !== UIViewController.self {
             return
         }
@@ -69,12 +70,12 @@ extension UIViewController {
         dispatch_once(&Static.token) {
             let originalSelector = Selector("viewWillAppear:")
             let swizzledSelector = Selector("nsh_viewWillAppear:")
-            
+
             let originalMethod = class_getInstanceMethod(self, originalSelector)
             let swizzledMethod = class_getInstanceMethod(self, swizzledSelector)
-            
+
             let didAddMethod = class_addMethod(self, originalSelector, method_getImplementation(swizzledMethod), method_getTypeEncoding(swizzledMethod))
-            
+
             if didAddMethod {
                 class_replaceMethod(self, swizzledSelector, method_getImplementation(originalMethod), method_getTypeEncoding(originalMethod))
             } else {
@@ -82,15 +83,15 @@ extension UIViewController {
             }
         }
     }
-    
+
     // MARK: - Method Swizzling
-    
+
     func nsh_viewWillAppear(animated: Bool) {
         self.nsh_viewWillAppear(animated)
         if let name = self.descriptiveName {
-            println("viewWillAppear: \(name)")
+            print("viewWillAppear: \(name)")
         } else {
-            println("viewWillAppear: \(self)")
+            print("viewWillAppear: \(self)")
         }
     }
 }
@@ -114,6 +115,3 @@ Instead of adding method swizzling via a class extension, simply add a method to
 
 
 In closing, remember that tinkering with the Objective-C runtime should be much more of a last resort than a place to start. Modifying the frameworks that your code is based upon, as well as any third-party code you run, is a quick way to destabilize the whole stack. Tread softly!
-
-
-

--- a/2015-01-26-swift-objc-runtime.md
+++ b/2015-01-26-swift-objc-runtime.md
@@ -5,7 +5,8 @@ category: "Swift"
 tags: swift
 excerpt: "Even when written without a single line of Objective-C code, every Swift app executes inside the Objective-C runtime, opening up a world of dynamic dispatch and associated runtime manipulation. To be sure, this may not always be the case—Swift-only frameworks, whenever they come, may lead to a Swift-only runtime. But as long as the Objective-C runtime is with us, let's use it to its fullest potential."
 status:
-    swift: 1.0
+    swift: 2.0
+    reviewed: September 19, 2015
 ---
 
 Even when written without a single line of Objective-C code, every Swift app executes inside the Objective-C runtime, opening up a world of dynamic dispatch and associated runtime manipulation. To be sure, this may not always be the case—Swift-only frameworks, whenever they come, may lead to a Swift-only runtime. But as long as the Objective-C runtime is with us, let's use it to its fullest potential.


### PR DESCRIPTION
- NSOrderedSet
  - Swift 2 check, and removed a few unneeded explicit types.
- NSOperation
  - Swift 2
- PHImageManager
  - Swift 2 and added Objective-C
- NSRange 
  - Added Swift translations. I translated this one-to-one with the Objective-C version, explicitly typing variables as NSString, NSArray, etc as needed to keep everything working on NSRanges instead of trying to use Swift's native Range. It felt kind of wrong, but a substantial overhaul of the article would be required to properly accommodate for Swift's Range (I think). Perhaps it deserves its own article.
  - I also kept the usage of global functions like NSMakeRange instead of converting them to use the appropriate struct initializers and instance methods for things like unions. Not sure which of the two is considered "better" practice, but if you'd like, I can rewrite it the other way.
- NSDateComponents
  - Swift 2
- NSPredicate
  - Swift 2
- Swift & the Obj-C Runtime
  - Swift 2