### PR TITLE
Custom operators in swift cannot contain any character

### DIFF
--- a/2014-08-11-swift-operators.md
+++ b/2014-08-11-swift-operators.md
@@ -384,7 +384,7 @@ This is all to say: **a custom operator should only ever be provided as a conven
 
 ### Use of Mathematical Symbols
 
-Custom operators can begin with one of the ASCII characters /, =, -, +, !, *, %, <, >, &, |, ^, or ~, or any of the Unicode characters in the "Math Symbols" character set.
+Custom operators can contain any of the following ASCII characters /, =, -, +, !, *, %, <, >, &, |, ^, or ~, or any of the Unicode characters in the "Math Symbols" character set.
 
 This makes it possible to take the square root of a number with a single `√` prefix operator (`⌥v`):
 


### PR DESCRIPTION
I tried various combinaisons of operators, and only the ones who contain the /, =, -, +, !, *, %, <, >, &, |, ^, or ~ and Math Symbols character set works.
Ex: =2√ or =2√ does not work but =√ works.