### PR TITLE
Improvements for Cocoa NSError conventions

### DIFF
--- a/2013-10-14-nserror.md
+++ b/2013-10-14-nserror.md
@@ -116,7 +116,7 @@ NSURLRequest *request = [NSURLRequest requestWithURL:URL];
 NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]];
 [[session dataTaskWithRequest:request
             completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
-    if (error) {
+    if (!data) {
         NSLog(@"%@", error);
     } else {
         // ...
@@ -132,15 +132,16 @@ To pass an error to an `NSError **` parameter, do the following:
 
 ~~~{objective-c}
 - (BOOL)validateObject:(id)object
-                 error:(NSError * __autoreleasing *)error
+                 error:(NSError * __autoreleasing *)outError
 {
-    BOOL success = ...;
+    NSError *error = nil;
+    BOOL success = ...; // call an API passing &error into its (NSError **) parameter
 
     if (!success) {
-      if (error) {
-        *error = [NSError errorWithDomain:NSHipsterErrorDomain
-                                     code:-42
-                                 userInfo:nil];
+      if (outError) {
+        *outError = [NSError errorWithDomain:NSHipsterErrorDomain
+                                        code:-42
+                                    userInfo:@{NSUnderlyingErrorKey: error}];
       }
     }
 


### PR DESCRIPTION
The first change is to check the result value before checking the error, as we would when calling an API that returns a value and an error in a trailing (NSError **) parameter.

The second change is to show how to wrap an underlying NSError in a NSError with a custom domain and code.