### PR TITLE
Update 2014-09-22-swift-comparison-protocols.md - specificity comparison condition fix

### DIFF
--- a/2014-09-22-swift-comparison-protocols.md
+++ b/2014-09-22-swift-comparison-protocols.md
@@ -168,8 +168,8 @@ extension CSSSelector.Specificity: Comparable {}
 
 func <(lhs: CSSSelector.Specificity, rhs: CSSSelector.Specificity) -> Bool {
     return lhs.id < rhs.id ||
-        lhs.`class` < rhs.`class` ||
-        lhs.element < rhs.element
+        (lhs.id == rhs.id && lhs.`class` < rhs.`class`) ||
+        (lhs.id == rhs.id && lhs.`class` == rhs.`class` && lhs.element < rhs.element)
 }
 
 // MARK: Equatable


### PR DESCRIPTION
Fix `CSSSelector.Specificity` comparison pointed out here: https://github.com/NSHipster/articles/commit/e4b977b30adc276ace718fa686e460a1a71d8d77#diff-6d92d5b6dd1d07f4ac6786ddc4e2c49cR167