### PR TITLE
Add -r flag to grep to fix error

### DIFF
--- a/2013-03-11-uiappearance.md
+++ b/2013-03-11-uiappearance.md
@@ -82,7 +82,7 @@ In order to find out what methods work with `UIAppearance`, you have to [look at
 ```
 $ cd /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/
   Developer/SDKs/iPhoneOS*.sdk/System/Library/Frameworks/UIKit.framework/Headers
-$ grep -H UI_APPEARANCE_SELECTOR ./* | sed 's/ __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_5_0) UI_APPEARANCE_SELECTOR;//'
+$ grep -rH UI_APPEARANCE_SELECTOR ./* | sed 's/ __OSX_AVAILABLE_STARTING(__MAC_NA,__IPHONE_5_0) UI_APPEARANCE_SELECTOR;//'
 ```
 
 `UIAppearance` looks for the `UI_APPEARANCE_SELECTOR` macro in method signatures. Any method with this annotation can be used with the `appearance` proxy.


### PR DESCRIPTION
Without the -r option the following error is displayed:

grep: ./Developer: Is a directory
grep: ./DeviceSupport: Is a directory
grep: ./usr: Is a directory

This is when using the default grep on OS X 10.11.3

```
> whereis grep
/usr/bin/grep

> grep --version
grep (BSD grep) 2.5.1-FreeBSD
```