### PR TITLE
Change Swift example to create UUID

### DIFF
--- a/2013-06-24-uuid-udid-unique-identifier.md
+++ b/2013-06-24-uuid-udid-unique-identifier.md
@@ -52,7 +52,7 @@ Users can opt out of ad targeting in a Settings screen added in iOS 6.1, found a
 `NSUUID` was added to Foundation in iOS 6 as a way to easily create UUIDs. How easy?
 
 ~~~{swift}
-let UUID = NSUUID.UUID().UUIDString
+let UUID = NSUUID().UUIDString
 ~~~
 
 ~~~{objective-c}


### PR DESCRIPTION
Hay, I made a small change about NSUUID article.

I just changed the Swift example code to use designated initialiser rather class method `UUID()` because the class method support Objective-C only.

Please have a look my changes and let me know if you got any concerns.

Thanks,
