### PR TITLE
Update 2013-07-22-uimenucontroller.md

### DIFF
--- a/2013-07-22-uimenucontroller.md
+++ b/2013-07-22-uimenucontroller.md
@@ -84,13 +84,17 @@ override func viewDidLoad() {
 // MARK: - UIGestureRecognizer
 
 func handleLongPressGesture(recognizer: UIGestureRecognizer) {
-	if let recognizerView = recognizer.view,
-		recognizerSuperView = recognizerView.superview
+        guard case .Recognized = recognizer.state else { return }
+        
+        if
+            let recognizerView = recognizer.view,
+            let recognizerSuperView = recognizerView.superview
+        where
+            recognizerView.becomeFirstResponder()
 	{
 		let menuController = UIMenuController.sharedMenuController()
 		menuController.setTargetRect(recognizerView.frame, inView: recognizerSuperView)
 		menuController.setMenuVisible(true, animated:true)
-		recognizerView.becomeFirstResponder()
 	}
 }
 ~~~
@@ -107,8 +111,7 @@ func handleLongPressGesture(recognizer: UIGestureRecognizer) {
 #pragma mark - UIGestureRecognizer
 
 - (void)handleLongPressGesture:(UIGestureRecognizer *)recognizer  {
-    if (recognizer.state == UIGestureRecognizerStateRecognized) {
-        [recognizer.view becomeFirstResponder];
+    if (recognizer.state == UIGestureRecognizerStateRecognized && [recognizer.view becomeFirstResponder]) {
         UIMenuController *menuController = [UIMenuController sharedMenuController];
         [menuController setTargetRect:recognizer.view.frame inView:recognizer.view.superview];
         [menuController setMenuVisible:YES animated:YES];


### PR DESCRIPTION
Fixed the order of making label a first responder and showing UIMenuViewController in swift code example. Without that menu will be shown only on the second long press. Also it makes sense to check the result of `becomeFirstResponder` before showing menu.
