### PR TITLE
fix PHImageManager cancellation

### DIFF
--- a/2014-09-16-phimagemanager.md
+++ b/2014-09-16-phimagemanager.md
@@ -52,8 +52,11 @@ func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexP
     cell.tag = Int(manager.requestImageForAsset(asset,
         targetSize: CGSize(width: 100.0, height: 100.0),
         contentMode: .AspectFill,
-        options: nil) { (result, _) in
-            cell.imageView?.image = result
+        options: nil) { (result, info) in
+            guard let info = info else { return }
+            if info[PHImageCancelledKey] == nil {
+                cell.imageView?.image = result
+            }
     })
 
     return cell


### PR DESCRIPTION
Hello,

I read your article http://nshipster.com/phimagemanager/ and I am wondering whether you have canceling request implemented in a correct manner.

PHImageCancelledKey
in the docs for `PHImageManager`, `PHImageCancelledKey` is explained as

> A Boolean value indicating whether the image request was canceled. (NSNumber)
> 
> If you call the cancelImageRequest: method to cancel a request, Photos calls your result handler block > with the value YES for this key.

so I believe we have to check its presence before calling `cell.imageView.image = result`.

Thanks
