### PR TITLE
CloudKit: Update CONTAINS to be BEGINSWITH instead

### DIFF
--- a/2015-06-29-cloudkit.md
+++ b/2015-06-29-cloudkit.md
@@ -219,10 +219,10 @@ While powerful, the convenience APIs aren't quite enough to finish our check-in 
 
 > `NSPredicate` plays an important role here, handling string matching, location and date ranging, and combinations of simple queries. Refer to the [`CKQuery` documentation for more](https://developer.apple.com/library/ios/documentation/CloudKit/Reference/CKQuery_class/index.html#//apple_ref/occ/cl/CKQuery).
 
-Let's say I want all places containing the name 'Apple Store':
+Let's say I want all places starting with the name 'Apple Store':
 
 ````swift
-let predicate = NSPredicate(format: "name CONTAINS 'Apple Store'")
+let predicate = NSPredicate(format: "name BEGINSWITH 'Apple Store'")
 let query = CKQuery(recordType: "Place", predicate: predicate)
 
 publicDB.performQuery(query, inZoneWithID: nil) { results, error in
@@ -230,7 +230,7 @@ publicDB.performQuery(query, inZoneWithID: nil) { results, error in
 }
 ````
 ````objective-c
-NSPredicate *predicate = [NSPredicate predicateWithFormat:@"name CONTAINS 'Apple Store'"];
+NSPredicate *predicate = [NSPredicate predicateWithFormat:@"name BEGINSWITH 'Apple Store'"];
 CKQuery *query = [[CKQuery alloc] initWithRecordType:@"Place" predicate:predicate];
     
 [publicDB performQuery:query
@@ -249,10 +249,10 @@ After adding queries, our application is almost complete. Or wait, did we forget
 
 Yes: notifications. They're a critical part of any check-in application. 
 
-For example, a social person may want to be notified if someone mentions "party" around him or her. This is possible with CloudKit—the framework already provides something to achieve this using the `CKSubscription` class:
+For example, a social person may want to be notified if someone mentions something starting with "party" around him or her; for example "party at Sarah's house". This is possible with CloudKit—the framework already provides something to achieve this using the `CKSubscription` class:
 
 ````swift
-let predicate = NSPredicate(format: "description CONTAINS 'party'")
+let predicate = NSPredicate(format: "description BEGINSWITH 'party'")
         
 let subscription = CKSubscription(recordType: "Checkin", predicate: predicate, options: .FiresOnRecordCreation)
         
@@ -270,7 +270,7 @@ publicDB.saveSubscription(subscription) { subscription, error in
 ````objective-c
 CKDatabase *publicDB = [[CKContainer defaultContainer] publicCloudDatabase];
     
-NSPredicate *predicate = [NSPredicate predicateWithFormat:@"description CONTAINS 'party'"];
+NSPredicate *predicate = [NSPredicate predicateWithFormat:@"description BEGINSWITH 'party'"];
     
 CKSubscription *subscription = [[CKSubscription alloc] initWithRecordType:@"Checkin" predicate:predicate options:CKSubscriptionOptionsFiresOnRecordCreation];
     


### PR DESCRIPTION
Since CloudKit does not allow "CONTAINS" to be used for string fields, only for collections.