### PR TITLE
Update 2014-07-14 NSOperation to Swift 3.0 syntax, and fix a deadlink, Convert 2013-12-09 MultipeerConnectivity to Swift 3.0

### DIFF
--- a/2013-12-09-multipeer-connectivity.md
+++ b/2013-12-09-multipeer-connectivity.md
@@ -73,7 +73,7 @@ As an example implementation, consider a client that allows the user to choose w
 //MARK: MCNearbyServiceAdvertiserDelegate
 
 func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
-    if self.mutableBlockedPeers.contains(peerID) {
+    if self.blockedPeers.contains(peerID) {
         invitationHandler(false, nil)
     }
     
@@ -83,8 +83,8 @@ func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFro
     let alertController = UIAlertController(title: NSLocalizedString("Received invitation from \(peerID.displayName)", comment: "Received invitation from {Peer}"), message: nil, preferredStyle: .actionSheet)
     let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel) { _ in invitationHandler(false, nil) }
     let blockAction = UIAlertAction(title: NSLocalizedString("Block", comment: ""), style: .destructive) { _ in
-        self.mutableBlockedPeers.append(peerID)
         invitationHandler(true, session)
+        self.blockedPeers.append(peerID)
     }
     let acceptAction = UIAlertAction(title: NSLocalizedString("Accept", comment: ""), style: .default) { _ in invitationHandler(true, session) }
     alertController.addAction(cancelAction)

--- a/2013-12-09-multipeer-connectivity.md
+++ b/2013-12-09-multipeer-connectivity.md
@@ -84,8 +84,8 @@ func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFro
     let alertController = UIAlertController(title: NSLocalizedString("Received invitation from \(peerID.displayName)", comment: "Received invitation from {Peer}"), message: nil, preferredStyle: .actionSheet)
     let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel) { _ in invitationHandler(false, nil) }
     let blockAction = UIAlertAction(title: NSLocalizedString("Block", comment: ""), style: .destructive) { _ in
-        invitationHandler(true, session)
         self.blockedPeers.append(peerID)
+        invitationHandler(false, nil)
     }
     let acceptAction = UIAlertAction(title: NSLocalizedString("Accept", comment: ""), style: .default) { _ in invitationHandler(true, session) }
     alertController.addAction(cancelAction)

--- a/2013-12-09-multipeer-connectivity.md
+++ b/2013-12-09-multipeer-connectivity.md
@@ -75,6 +75,7 @@ As an example implementation, consider a client that allows the user to choose w
 func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didReceiveInvitationFromPeer peerID: MCPeerID, withContext context: Data?, invitationHandler: @escaping (Bool, MCSession?) -> Void) {
     if self.blockedPeers.contains(peerID) {
         invitationHandler(false, nil)
+        return
     }
     
     let session = MCSession(peer: localPeerID, securityIdentity: nil, encryptionPreference: .none)

--- a/2014-07-14-nsoperation.md
+++ b/2014-07-14-nsoperation.md
@@ -5,8 +5,8 @@ category: Cocoa
 tags: nshipster
 excerpt: "In life, there's always work to be done. Every day brings with it a steady stream of tasks and chores to fill the working hours of our existence. Productivity is, as in life as it is in programming, a matter of scheduling and prioritizing and multi-tasking work in order to keep up appearances."
 status:
-    swift: 2.0
-    reviewed: September 15, 2015
+    swift: 3.0
+    reviewed: December 24, 2016
 ---
 
 In life, there's always work to be done. Every day brings with it a steady stream of tasks and chores to fill the working hours of our existence.
@@ -67,12 +67,12 @@ All operations may not be equally important. Setting the `queuePriority` propert
 ### NSOperationQueuePriority
 
 ~~~{swift}
-public enum NSOperationQueuePriority : Int {
-    case VeryLow
-    case Low
-    case Normal
-    case High
-    case VeryHigh
+public enum QueuePriority : Int {
+    case veryLow
+    case low
+    case normal
+    case high
+    case veryHigh
 }
 ~~~
 ~~~{objective-c}
@@ -101,12 +101,12 @@ The following enumerated values are used to denote the nature and urgency of an 
 
 ~~~{swift}
 @available(iOS 8.0, OSX 10.10, *)
-public enum NSQualityOfService : Int {    
-    case UserInteractive
-    case UserInitiated
-    case Utility
-    case Background
-    case Default
+public enum QualityOfService : Int {    
+    case userInteractive
+    case userInitiated
+    case utility
+    case background
+    case `default`
 }
 ~~~
 ~~~{objective-c}
@@ -119,18 +119,18 @@ typedef NS_ENUM(NSInteger, NSQualityOfService) {
 } NS_ENUM_AVAILABLE(10_10, 8_0);
 ~~~
 
-- `.UserInteractive`:UserInteractive QoS is used for work directly involved in providing an interactive UI such as processing events or drawing to the screen.
-- `.UserInitiated`: UserInitiated QoS is used for performing work that has been explicitly requested by the user and for which results must be immediately presented in order to allow for further user interaction.  For example, loading an email after a user has selected it in a message list.
-- `.Utility`: Utility QoS is used for performing work which the user is unlikely to be immediately waiting for the results.  This work may have been requested by the user or initiated automatically, does not prevent the user from further interaction, often operates at user-visible timescales and may have its progress indicated to the user by a non-modal progress indicator.  This work will run in an energy-efficient manner, in deference to higher QoS work when resources are constrained.  For example, periodic content updates or bulk file operations such as media import.
-- `.Background`: Background QoS is used for work that is not user initiated or visible.  In general, a user is unaware that this work is even happening and it will run in the most efficient manner while giving the most deference to higher QoS work.  For example, pre-fetching content, search indexing, backups, and syncing of data with external systems.
-- `.Default`: Default QoS indicates the absence of QoS information.  Whenever possible QoS information will be inferred from other sources.  If such inference is not possible, a QoS between UserInitiated and Utility will be used.
+- `.userInteractive`:UserInteractive QoS is used for work directly involved in providing an interactive UI such as processing events or drawing to the screen.
+- `.userInitiated`: UserInitiated QoS is used for performing work that has been explicitly requested by the user and for which results must be immediately presented in order to allow for further user interaction.  For example, loading an email after a user has selected it in a message list.
+- `.utility`: Utility QoS is used for performing work which the user is unlikely to be immediately waiting for the results.  This work may have been requested by the user or initiated automatically, does not prevent the user from further interaction, often operates at user-visible timescales and may have its progress indicated to the user by a non-modal progress indicator.  This work will run in an energy-efficient manner, in deference to higher QoS work when resources are constrained.  For example, periodic content updates or bulk file operations such as media import.
+- `.background`: Background QoS is used for work that is not user initiated or visible.  In general, a user is unaware that this work is even happening and it will run in the most efficient manner while giving the most deference to higher QoS work.  For example, pre-fetching content, search indexing, backups, and syncing of data with external systems.
+- `.default`: Default QoS indicates the absence of QoS information.  Whenever possible QoS information will be inferred from other sources.  If such inference is not possible, a QoS between UserInitiated and Utility will be used.
 
 ~~~{swift}
-let backgroundOperation = NSOperation()
-backgroundOperation.queuePriority = .Low
-backgroundOperation.qualityOfService = .Background
+let backgroundOperation = Operation()
+backgroundOperation.queuePriority = .low
+backgroundOperation.qualityOfService = .background
 
-let operationQueue = NSOperationQueue.mainQueue()
+let operationQueue = OperationQueue.main
 operationQueue.addOperation(backgroundOperation)
 ~~~
 ~~~{objective-c}
@@ -156,11 +156,11 @@ For example, to describe the process of downloading and resizing an image from a
 Expressed in code:
 
 ~~~{swift}
-let networkingOperation: NSOperation = ...
-let resizingOperation: NSOperation = ...
+let networkingOperation: Operation = ...
+let resizingOperation: Operation = ...
 resizingOperation.addDependency(networkingOperation)
 
-let operationQueue = NSOperationQueue.mainQueue()
+let operationQueue = OperationQueue.main
 operationQueue.addOperations([networkingOperation, resizingOperation], waitUntilFinished: false)
 ~~~
 
@@ -183,12 +183,12 @@ Make sure not to accidentally create a dependency cycle, such that A depends on 
 When an `NSOperation` finishes, it will execute its `completionBlock` exactly once. This provides a really nice way to customize the behavior of an operation when used in a model or view controller.
 
 ~~~{swift}
-let operation = NSOperation()
+let operation = Operation()
 operation.completionBlock = {
     print("Completed")
 }
 
-NSOperationQueue.mainQueue().addOperation(operation)
+OperationQueue.main.addOperation(operation)
 ~~~
 
 ~~~{objective-c}

--- a/2014-07-14-nsoperation.md
+++ b/2014-07-14-nsoperation.md
@@ -23,7 +23,7 @@ The secret to making apps snappy is to offload as much unnecessary work to the b
 
 > For situations where it doesn't make sense to build out a custom `NSOperation` subclass, Foundation provides the concrete implementations [`NSBlockOperation`](https://developer.apple.com/library/ios/documentation/cocoa/reference/NSBlockOperation_class/Reference/Reference.html) and [`NSInvocationOperation`](https://developer.apple.com/library/mac/documentation/cocoa/reference/NSInvocationOperation_Class/Reference/Reference.html).
 
-Examples of tasks that lend themselves well to `NSOperation` include [network requests](https://github.com/AFNetworking/AFNetworking/blob/master/AFNetworking/AFURLConnectionOperation.h), image resizing, text processing, or any other repeatable, structured, long-running task that produces associated state or data.
+Examples of tasks that lend themselves well to `NSOperation` include [network requests](https://github.com/AFNetworking/AFNetworking/blob/2.x/AFNetworking/AFURLConnectionOperation.h), image resizing, text processing, or any other repeatable, structured, long-running task that produces associated state or data.
 
 But simply wrapping computation into an object doesn't do much without a little oversight. That's where `NSOperationQueue` comes in:
 


### PR DESCRIPTION
I've updated sample code to Swift 3.0.

However, I left classes names (i.e. `NSBlockOperation`) in the article as is, since it wouldn't make lot of sense with the Objective-C sample code.

Also, I fixed a deadlink to make it point to the legacy `AFURLConnectionOperation.h` file which was still present in AFNetworking 2.x. (Removed in AFNetworking 3.0, hence the deadlink)