### PR TITLE
Update 2018-07-09-swift-gyb.md

### DIFF
--- a/2018-07-09-swift-gyb.md
+++ b/2018-07-09-swift-gyb.md
@@ -91,7 +91,7 @@ methods declarations for the protocol's requirements:
 
 ```python
 % for type in codable_types:
-  mutating func encode(_ value: ${type}, forKey key: Key) throws
+  mutating func encode(_ value: ${type}) throws
 % end
 ```
 


### PR DESCRIPTION
The generated code looks to not match the gym template. 

Thought about adding the `, forKey key: Key` to each output function but that muddies the example output.