### PR TITLE
Fix small error in "excessive indentation" code sample

### DIFF
--- a/2015-10-05-guard-and-defer.md
+++ b/2015-10-05-guard-and-defer.md
@@ -130,7 +130,7 @@ func readBedtimeStory() throws {
     if let url = Bundle.main.url(forResource: "book",
                                withExtension: "txt")
     {
-        if let data = try Data(contentsOf: url),
+        if let data = try? Data(contentsOf: url),
             let story = String(data: data, encoding: .utf8)
         {
             if story.contains("👹") {


### PR DESCRIPTION
This PR fixes a small compiler error in the "Guarding Against Excessive Indentation and Errors" section.

The "before" code sample fails to compile because the expression `try Data(contentsOfUrl: url)` does not produce an Optional result. I updated it to match the "after" code sample, which uses `try?` instead (see line 177).