### PR TITLE
Hashable/Hasher: Add a few missing words

### DIFF
--- a/2018-08-13-hashable.md
+++ b/2018-08-13-hashable.md
@@ -94,9 +94,9 @@ struct Color {
 ```
 
 To conform to `Equatable`,
-had to provide an implementation for the `==` operator.
+you had to provide an implementation for the `==` operator.
 To conform to `Hashable`,
-had to provide an implementation of the computed `hashValue` property:
+you had to provide an implementation of the computed `hashValue` property:
 
 ```swift
 // Swift < 4.1
@@ -158,7 +158,7 @@ if their members also conform to those protocols.
 In addition to being a huge boost to developer productivity,
 this can drastically reduce the size of a codebase.
 For instance, our `Color` example from before ---
-now ⅓ of its original size:
+is now ⅓ of its original size:
 
 ```swift
 // Swift >= 4.1
@@ -295,7 +295,7 @@ to make hash values even less predictable.
 The challenge of programming analogies
 is they normalize antisocial behavior by way of edge cases.
 
-We excel as software engineers when they can think through
+We excel as software engineers when we can think through
 all the ways that an attacker might leverage a particular behavior
 to some sinister end --- as in the case of hash-flooding DoS attacks.
 But by doing so,


### PR DESCRIPTION
This also fixes one other error (they/we).