### PR TITLE
Use correct env variable when setting simulator language

### DIFF
--- a/2018-11-26-simctl.md
+++ b/2018-11-26-simctl.md
@@ -327,13 +327,13 @@ For example, the following shell script
 changes the current locale and language to Japanese:
 
 ```bash
-PLIST="~/Library/Developer/CoreSimulator/Devices/$UUID/data/Library/Preferences/.GlobalPreferences.plist"
+PLIST=~/Library/Developer/CoreSimulator/Devices/$UUID/data/Library/Preferences/.GlobalPreferences.plist
 
 LANGUAGE="ja"
 LOCALE="ja_JP"
 
 plutil -replace AppleLocale -string $LOCALE $PLIST
-plutil -replace AppleLanguages -json "[ \"$LOCALE\" ]" $PLIST
+plutil -replace AppleLanguages -json "[ \"$LANGUAGE\" ]" $PLIST
 ```
 
 You can use this same technique to adjust Accessibility settings

--- a/2018-11-26-simctl.md
+++ b/2018-11-26-simctl.md
@@ -332,8 +332,8 @@ PLIST=~/Library/Developer/CoreSimulator/Devices/$UUID/data/Library/Preferences/.
 LANGUAGE="ja"
 LOCALE="ja_JP"
 
-plutil -replace AppleLocale -string $LOCALE $PLIST
-plutil -replace AppleLanguages -json "[ \"$LANGUAGE\" ]" $PLIST
+plutil -replace AppleLocale -string $LOCALE "$PLIST"
+plutil -replace AppleLanguages -json "[ \"$LANGUAGE\" ]" "$PLIST"
 ```
 
 You can use this same technique to adjust Accessibility settings


### PR DESCRIPTION
- Also fix an error `plutil` throws when using double quotes for the file name:
`file does not exist or is not readable or is not a regular file`