### PR TITLE
Update 2018-11-26-simctl.md

### DIFF
--- a/2018-11-26-simctl.md
+++ b/2018-11-26-simctl.md
@@ -192,11 +192,11 @@ might be opposite of what you'd expect:
 For example,
 if you wanted to copy the contents of a file on my Desktop
 to the pasteboard of a simulated device,
-you'd use the `pbpaste` subcommand like so:
+you'd use the `pbcopy` subcommand like so:
 
 ```terminal
 $ pbcopy ~/Desktop/file.txt
-$ xcrun simctl pbpaste booted
+$ pbpaste | xcrun simctl pbcopy booted
 ```
 
 After running these commands,


### PR DESCRIPTION
Hi,

I was reading the article on `simctl` and was really confused about the example for pasting to the simulator. The example was doing the opposite of the explanation, which explained that the commands are counter-intuitive. 

I tried it out on my machine, but couldn't get it to work. The documentation for `pbcopy` and `pbpaste` states:

```man
pbcopy              Copy standard input onto the device pasteboard.
pbpaste             Print the contents of the device's pasteboard to standard output.
```

So `pbcopy` reads from standard input onto the device pasteboard. So we definitely want to use `pbcopy` and not `pbpaste`. But since it's from standard output we actually have to put the computer's pasteboard onto standard output via `pbpaste` for the `simctl` to consume with `pbcopy`.

I hope this makes sense? I did it as a PR, but maybe I should just have opened an issue.

Anyway, keep up the good work with these great articles. 