### PR TITLE
Fix plutil code example in 2018-11-26-simctl.md

### DIFF
--- a/2018-11-26-simctl.md
+++ b/2018-11-26-simctl.md
@@ -333,7 +333,7 @@ LANGUAGE="ja"
 LOCALE="ja_JP"
 
 plutil -replace AppleLocale -string $LOCALE $PLIST
-plutil -replace AppleLanguages -json "[ \"$LOCALE\" ]" $PLIST
+plutil -replace AppleLanguages -json "[ \"$LANGUAGE\" ]" $PLIST
 ```
 
 You can use this same technique to adjust Accessibility settings


### PR DESCRIPTION
This pr is for fixing the `plutil` AppleLanguages code example to use `LANGUAGE`.