### PR TITLE
Fixed crash in swift 4.2 with NSPredicate, and renamed a filter method to the new name

### DIFF
--- a/2013-07-15-nspredicate.md
+++ b/2013-07-15-nspredicate.md
@@ -25,13 +25,13 @@ It's easier to show `NSPredicate` in use, rather than talk about it in the abstr
     let firstName: String
     let lastName: String
     let age: Int
-    
+
     init(firstName: String, lastName: String, age: Int) {
         self.firstName = firstName
         self.lastName = lastName
         self.age = age
     }
-    
+
     override var description: String {
         return "\(firstName) \(lastName)"
     }

--- a/2013-07-15-nspredicate.md
+++ b/2013-07-15-nspredicate.md
@@ -21,17 +21,17 @@ It's easier to show `NSPredicate` in use, rather than talk about it in the abstr
 | Quentin     | Alberts    | 31    |
 
 ```swift
-class Person: NSObject {
+@objcMembers  class Person: NSObject {
     let firstName: String
     let lastName: String
     let age: Int
-
+    
     init(firstName: String, lastName: String, age: Int) {
         self.firstName = firstName
         self.lastName = lastName
         self.age = age
     }
-
+    
     override var description: String {
         return "\(firstName) \(lastName)"
     }
@@ -47,13 +47,13 @@ let bobPredicate = NSPredicate(format: "firstName = 'Bob'")
 let smithPredicate = NSPredicate(format: "lastName = %@", "Smith")
 let thirtiesPredicate = NSPredicate(format: "age >= 30")
 
-(people as NSArray).filteredArrayUsingPredicate(bobPredicate)
+(people as NSArray).filtered(using: bobPredicate)
 // ["Bob Jones"]
 
-(people as NSArray).filteredArrayUsingPredicate(smithPredicate)
+(people as NSArray).filtered(using: smithPredicate)
 // ["Alice Smith", "Charlie Smith"]
 
-(people as NSArray).filteredArrayUsingPredicate(thirtiesPredicate)
+(people as NSArray).filtered(using: thirtiesPredicate)
 // ["Charlie Smith", "Quentin Alberts"]
 ```
 


### PR DESCRIPTION
It was a crash because you have to mark members of the class to be key/value complaint.
