### PR TITLE
Fix pbcopy example in simctl article

### DIFF
--- a/2018-11-26-simctl.md
+++ b/2018-11-26-simctl.md
@@ -195,7 +195,7 @@ to the pasteboard of a simulated device,
 you'd use the `pbpaste` subcommand like so:
 
 ```terminal
-$ pbcopy ~/Desktop/file.txt
+$ cat ~/Desktop/file.txt | pbcopy
 $ xcrun simctl pbpaste booted
 ```
 


### PR DESCRIPTION
I may be missing something, but I'm pretty sure the only way to use `pbcopy` is to pipe something into it, e.g. `cat ~/Desktop/file.txt | pbcopy`. Running the command in the article, `pbcopy ~/Desktop/file.txt`, waits for more input on the command line.

Side note: I'm also confused by the definitions of `pbcopy` and `pbpaste` in the article. The article says "`pbpaste` takes the pasteboard contents of the Simulator and copies them to the desktop's main pasteboard". However, the example clearly does the opposite: takes the contents of the desktop's main pasteboard and copies it to the Simulator's pasteboard. The example is correct; running the command in the article after the corrected `pbcopy` command works as the article intends. However, your description also matches Apple's documentation when you run `xcrun simctl pbpaste --help`. So, the docs don't seem to be in sync with the example.