### PR TITLE
Correct typo in named capture groups section

### DIFF
--- a/2019-02-11-swift-regular-expressions.md
+++ b/2019-02-11-swift-regular-expressions.md
@@ -327,7 +327,7 @@ gosh, wouldn't it be nice if we could play Cluedo solo?
 
 ### Matching Multi-Line Patterns with Named Capture Groups
 
-The only thing making Cluedo a strictly single-player affair
+The only thing making Cluedo a strictly multiplayer affair
 is that you need some way to test a theory
 without revealing the answer to yourself.
 


### PR DESCRIPTION
This example only makes sense if “single-player” is supposed to be “multiplayer”.