### PR TITLE
Escape period (.) in regular expressions

### DIFF
--- a/2019-02-11-swift-regular-expressions.md
+++ b/2019-02-11-swift-regular-expressions.md
@@ -219,7 +219,7 @@ the problem of the mysterious murder of Dr. Black.
 """
 
 instructions.replacingOccurrences(
-    of: #"(Dr.|Doctor) Black"#,
+    of: #"(Dr\.|Doctor) Black"#,
     with: "Mr. Boddy",
     options: .regularExpression
 )
@@ -358,12 +358,12 @@ which lets us do some really nice things:
 let pattern = #"""
 (?xi)
 (?<suspect>
-    ((Miss|Ms.) \h Scarlett?) |
-    ((Colonel | Col.) \h Mustard) |
-    ((Reverend | Mr.) \h Green) |
-    (Mrs. \h Peacock) |
-    ((Professor | Prof.) \h Plum) |
-    ((Mrs. \h White) | ((Doctor | Dr.) \h Orchid))
+    ((Miss|Ms\.) \h Scarlett?) |
+    ((Colonel | Col\.) \h Mustard) |
+    ((Reverend | Mr\.) \h Green) |
+    (Mrs\. \h Peacock) |
+    ((Professor | Prof\.) \h Plum) |
+    ((Mrs\. \h White) | ((Doctor | Dr\.) \h Orchid))
 ),?(?-x: in the )
 (?<location>
     Kitchen        | Ballroom | Conservatory |


### PR DESCRIPTION
The period (full stop, dot) is a special symbol in regular expressions that matches any character, excluding newline. ([Unless the *s* flag is set.](https://developer.apple.com/documentation/foundation/nsregularexpression#1965592))

To match a literal period, the symbol must be escaped.