### PR TITLE
Bug in "Named Capture Groups" example

### DIFF
--- a/2019-02-11-swift-regular-expressions.md
+++ b/2019-02-11-swift-regular-expressions.md
@@ -341,7 +341,7 @@ into its component parts:
 ```swift
 let suggestion = """
 I suspect it was Professor Plum, \
-in the Dining Room,              \
+in the Dining Room, \
 with the Candlestick.
 """
 ```


### PR DESCRIPTION
The "Matching Multi-Line Patterns with Named Capture Groups" example has a minor bug that breaks the match.  Specifically, the multiple spaces after "Dining Room" are not matched.

Proposed fix is to only have one space character in the "suggestion" string.