### PR TITLE
Update 2019-03-11-mapkit-js.md

### DIFF
--- a/2019-03-11-mapkit-js.md
+++ b/2019-03-11-mapkit-js.md
@@ -448,8 +448,8 @@ MapKit JS should be familiar to anyone familiar with
 the original MapKit framework on iOS and macOS.
 For example,
 when you initialize a map,
-you configure its initial view
-by either constructing a region from
+you can configure its initial view
+by constructing a region from
 a fixed distance around center point.
 
 ```javascript


### PR DESCRIPTION
not sure but i think « either » was used because it was intended to show two different options but only one option was talked about.
as always, thanks for the articles, and hopefully im not wrong on this one