### PR TITLE
Add automation script to 2018-11-19-vscode

### DIFF
--- a/2018-11-19-vscode.md
+++ b/2018-11-19-vscode.md
@@ -89,7 +89,7 @@ its performance and memory footprint are comparable to a native app.
 
 ## Step 2: Install the Latest Swift Toolchain
 
-Go to [Swift.org](https://swift.org/download/)
+Go to [Swift.org](https://swift.org/download/#snapshots)
 and download the latest trunk development snapshot
 (at the time of writing, this was from November 16th, 2018).
 Once it's finished downloading,

--- a/2018-11-19-vscode.md
+++ b/2018-11-19-vscode.md
@@ -193,6 +193,16 @@ and the [Swift Lint extension](https://marketplace.visualstudio.com/items?itemNa
 
 {% endinfo %}
 
+{% info %}
+
+Don't want to run all the commands yourself? Looking for a way to keep SourceKit-LSP updated without having to dig back through this article? We've got you covered with a handy [script](https://gist.githubusercontent.com/bdrelling/371aded288f26da549d60531cfca3c97/raw/) that flies through all the steps above and tries to automate what it can or instruct you when it can't.
+
+You can also just run `bash <(curl -s https://gist.githubusercontent.com/bdrelling/371aded288f26da549d60531cfca3c97/raw/)` in your terminal. 
+
+If you already have `apple/sourcekit-lsp` cloned, we recommend you run this script (or command) in that directory. Otherwise, the script will clone the `apple/sourcekit-lsp` repo into _another_ directory.
+
+{% endinfo %}
+
 ---
 
 So there you have it ---

--- a/2018-11-19-vscode.md
+++ b/2018-11-19-vscode.md
@@ -175,6 +175,12 @@ $ npm run createDevPackage
 $ code --install-extension out/sourcekit-lsp-vscode-dev.vsix
 ```
 
+{% warning %}
+
+As of May 26th, 2019, the `npm run createDevPackage` command fails. To fix this, simply run `npm install -S @types/lodash@4.14.132`, then run the last two commands in the snippet above.
+
+{% endwarning %}
+
 Now launch (or relaunch) VSCode and open a Swift project,
 such as [this one](https://github.com/flight-school/money),
 and enjoy an early preview of the functionality provided by


### PR DESCRIPTION
**Summary**

Your guide walks the user through a bunch of commands, so I thought it would work well as a script! You can view that script [here](https://gist.githubusercontent.com/bdrelling/371aded288f26da549d60531cfca3c97/raw/).

**Details**

- Wrote a [script](https://gist.githubusercontent.com/bdrelling/371aded288f26da549d60531cfca3c97/raw/) to automate all but Step 2 in the article. 
- Fixed snapshots link to point directly to the snapshots section.

**Additional Notes**

- I don't mind if you'd rather host the script somewhere other than a gist. I can put it up on my website or you can just put it on the nshipster.com repo?
- It would be unnecessarily difficult to automate getting and setting the latest version of the Swift toolchain. It'll still have to be done manually. I `echo` this out to the user since it can be done at any step. If there is a latest version of the toolchain, I set `SOURCEKIT_TOOLCHAIN_PATH` with the path (per apple/sourcekit-lsp).
- I put some filler text in the article, I imagine you'd want to adjust this to match the rest of the copy.
- The article currently updates the toolchain in Xcode, but it might be good to include steps to either set `SOURCEKIT_TOOLCHAIN_PATH` or just set it in vscode manually:

![image](https://user-images.githubusercontent.com/3022693/58377687-ce2f6c80-7f4b-11e9-8bff-805a199679ff.png)