### PR TITLE
Moves </blockquote> to new line in “Associated Objects”

### DIFF
--- a/2014-02-10-associated-objects.md
+++ b/2014-02-10-associated-objects.md
@@ -60,7 +60,8 @@ objc_getAssociatedObject(self, &kAssociatedObjectKey);
 
 However, a much simpler solution exists: just use a selector.
 
-<blockquote class="twitter-tweet" lang="en"><p>Since <tt>SEL</tt>s are guaranteed to be unique and constant, you can use <tt>_cmd</tt> as the key for <tt>objc_setAssociatedObject()</tt>. <a href="https://twitter.com/search?q=%23objective&amp;src=hash">#objective</a>-c <a href="https://twitter.com/search?q=%23snowleopard&amp;src=hash">#snowleopard</a></p>&mdash; Bill Bumgarner (@bbum) <a href="https://twitter.com/bbum/statuses/3609098005">August 28, 2009</a></blockquote>
+<blockquote class="twitter-tweet" lang="en"><p>Since <tt>SEL</tt>s are guaranteed to be unique and constant, you can use <tt>_cmd</tt> as the key for <tt>objc_setAssociatedObject()</tt>. <a href="https://twitter.com/search?q=%23objective&amp;src=hash">#objective</a>-c <a href="https://twitter.com/search?q=%23snowleopard&amp;src=hash">#snowleopard</a></p>&mdash; Bill Bumgarner (@bbum) <a href="https://twitter.com/bbum/statuses/3609098005">August 28, 2009</a>
+</blockquote>
 <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 ## Associative Object Behaviors


### PR DESCRIPTION
It's being interpreted as text-in-need-of-escaping where it is.

Before:
<img width="300" alt="Screen Shot 2019-05-28 at 9 09 51 AM" src="https://user-images.githubusercontent.com/13492/58485774-4a7fa680-812a-11e9-8b3b-ba35e4394ce0.png">

After:
<img width="300" alt="Screen Shot 2019-05-28 at 9 11 40 AM" src="https://user-images.githubusercontent.com/13492/58485790-510e1e00-812a-11e9-8827-4fa76c511b5c.png">


fixes #621