### PR TITLE
Correct typo in Silver Bullets section

### DIFF
--- a/2019-06-12-wwdc-2019.md
+++ b/2019-06-12-wwdc-2019.md
@@ -412,7 +412,7 @@ that will have a more immediate impact on your users and your own career.
 ### Silver Bullets and Universal Truths
 
 SwiftUI solves some of the most visible problems facing Apple platforms,
-but these aren't the most important are most difficult of software development ---
+but these aren't the most important or most difficult of software development ---
 not by a long shot.
 
 Taking care of yourself ---


### PR DESCRIPTION
“most important are most difficult” is presumably supposed to be “most important or most difficult”.