### PR TITLE
Update property delegates proposal link to property wrapper

### DIFF
--- a/2019-06-12-wwdc-2019.md
+++ b/2019-06-12-wwdc-2019.md
@@ -85,7 +85,7 @@ struct Content: View {
 
 Even if you ardently followed the [Swift Forums](https://forums.swift.org)
 and knew about the proposals for
-[property delegates](https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-delegates.md),
+[property wrappers](https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md),
 [implicit returns for single-line expressions](https://github.com/apple/swift-evolution/blob/master/proposals/0255-omit-return.md), and
 [opaque result types](https://github.com/apple/swift-evolution/blob/master/proposals/0244-opaque-result-types.md)...
 you still might struggle to


### PR DESCRIPTION
**Summary**

The Swift Evolution repo renamed the proposal Property Delegates to Property Wrappers in this PR (https://github.com/apple/swift-evolution/commit/45cd354843860e9cc29c333b40028aab624503ad#diff-9c53e762ad01892b861f183ad16e76aa). 

**Fix**

I updated the link and name.