### PR TITLE
Minor fixes

### DIFF
--- a/2014-10-28-cmdevicemotion.md
+++ b/2014-10-28-cmdevicemotion.md
@@ -222,7 +222,7 @@ and presents each as its own property of the `CMDeviceMotion` object.
 The code is very similar to our first example:
 
 ```swift
-if manager.isDeviceMotionActive {
+if manager.isDeviceMotionAvailable {
     manager.deviceMotionUpdateInterval = 0.01
     manager.startDeviceMotionUpdates(to: .main) {
         [weak self] (data, error) in
@@ -259,7 +259,7 @@ that's our cue to pop the view controller from the stack.
 The implementation is only a couple lines different from our previous example:
 
 ```swift
-if manager.isDeviceMotionActive {
+if manager.isDeviceMotionAvailable {
     manager.deviceMotionUpdateInterval = 0.01
     manager.startDeviceMotionUpdates(to: .main) {
         [weak self] (data, error) in
@@ -395,7 +395,7 @@ we calculate the magnitude of the vector described by the three Euler angles
 and use that as a trigger to show or hide the prompt view:
 
 ```swift
-if manager.isDeviceMotionActive {
+if manager.isDeviceMotionAvailable {
     manager.startDeviceMotionUpdates(to: .main) {
         // translate the attitude
         data.attitude.multiply(byInverseOf: initialAttitude)
@@ -453,7 +453,7 @@ A better approach would be to schedule these updates on their own queue
 and dispatch back to main to update the UI.
 
 ```swift
-let queue = DispatchQueue(label: "motion")
+let queue = OperationQueue()
 manager.startDeviceMotionUpdates(to: queue) {
     [weak self] (data, error) in
 


### PR DESCRIPTION
1) `isDeviceMotionActive`->`isDeviceMotionAvailable` This is a typo I think. Compare with line 163 where `manager.isAccelerometerAvailable` is checked. Makes no sense to check if it is active before starting. Makes more sense to check if its available. 

2) 
`startDeviceMotionUpdates` takes `OperationQueue` not a `DispatchQueue`. Jumping to definition we see:
```
    open func startDeviceMotionUpdates(to queue: OperationQueue, withHandler handler: @escaping CMDeviceMotionHandler)
```

That said, I still haven't been able to view these demos; these were just the changes needed to get it to compile and get to `startDeviceMotionUpdates`. For some reason the closure is still not running for me.