### PR TITLE
Adding checkout line for `swift-format`

### DIFF
--- a/2019-05-20-swift-format.md
+++ b/2019-05-20-swift-format.md
@@ -535,6 +535,7 @@ You can check it out and build it from source by running the following commands:
 ```terminal
 $ git clone https://github.com/google/swift.git swift-format
 $ cd swift-format
+$ git checkout format
 $ git submodule update --init
 $ swift build
 ```


### PR DESCRIPTION
When checking out the `swift-format` tool, I'm fairly certain that the default branch was `contributing`. Tripped me up for a sec, since I didn't think that I was on the incorrect branch until I ran `swift build` and it complained that nothing was there :)