### PR TITLE
Replace "&nbsp;" in an article title with the actual character

### DIFF
--- a/2015-02-02-ibinspectable-ibdesignable.md
+++ b/2015-02-02-ibinspectable-ibdesignable.md
@@ -1,5 +1,5 @@
 ---
-title: "IBInspectable&nbsp;/ IBDesignable"
+title: "IBInspectable / IBDesignable"
 category: Xcode
 author: Nate Cook
 excerpt: "Replacing an interface that requires us to memorize and type with one we can see and manipulate can be a enormous improvement. With `IBInspectable` and `IBDesignable`, Xcode 6 makes just such a substitution, building new interactions on top of old technologies."


### PR DESCRIPTION
Entities are apparently not valid in article titles and the "nbsp;" was showing up literally in the rendered page.