### PR TITLE
add "case" to fix compilation error

### DIFF
--- a/2019-09-23-ios-13.md
+++ b/2019-09-23-ios-13.md
@@ -289,7 +289,7 @@ webSocketTask.send(message) { error in
 
 // Receive one message
 webSocketTask.receive { result in
-    guard let .success(message) = result else { return }
+    guard case let .success(message) = result else { return }
     <#...#>
 }
 


### PR DESCRIPTION
"Pattern matching in a condition requires the 'case' keyword"