### PR TITLE
updated release notes for supportsOnDeviceRecognition

### DIFF
--- a/2019-09-23-ios-13.md
+++ b/2019-09-23-ios-13.md
@@ -213,15 +213,18 @@ Chinese
 
 </figure>
 
-{% error %}
+{% warning %}
 
-According to the iOS 13 release notes:
+According to the iOS 13 release notes, prior to iOS 13.2:
 "The `supportsOnDeviceRecognition` property always returns `false`
 the first time it’s accessed.
 After a few seconds,
 accessing it again returns the correct value."
 
-{% enderror %}
+As of 13.2 this is resolved:
+"The supportsOnDeviceRecognition property now returns the correct value. (47822242)"
+
+{% warning %}
 
 But that's not all for speech recognition in iOS 13!
 `SFSpeechRecognizer` now provides information including


### PR DESCRIPTION
as of iOS 13.2 The supportsOnDeviceRecognition property now returns the correct value. (47822242)