### PR TITLE
Edit build configuration in 2018-11-19-vscode.md

### DIFF
--- a/2018-11-19-vscode.md
+++ b/2018-11-19-vscode.md
@@ -133,17 +133,17 @@ and build the Swift project.
 ```terminal
 $ git clone https://github.com/apple/sourcekit-lsp.git
 $ cd sourcekit-lsp
-$ swift build
+$ swift build -c release
 ```
 
 If successful,
 the completed binary will be available from
-of the hidden `.build/debug` directory.
+of the hidden `.build/release` directory.
 Move that binary to a standard directory in your `$PATH`,
 like `/usr/local/bin` or `/usr/bin`.
 
 ```terminal
-$ mv .build/debug/sourcekit-lsp /usr/local/bin
+$ mv .build/release/sourcekit-lsp /usr/local/bin
 ```
 
 You can verify that everything is working as expected


### PR DESCRIPTION
In the article you build default (debug) configuration for sourcekit-lsp binary usage. I think release configuration will be more appropriate for end user.