### PR TITLE
Update 2019-09-23-ios-13.md

### DIFF
--- a/2019-09-23-ios-13.md
+++ b/2019-09-23-ios-13.md
@@ -108,7 +108,6 @@ import LinkPresentation
 let metadataProvider = LPMetadataProvider()
 let url = URL(string: "{{ page.url | absolute_url }}")!
 
-let metadataProvider = LPMetadataProvider()
 metadataProvider.startFetchingMetadata(for: url) { [weak self] metadata, error in
     guard let metadata = metadata else { return }
 


### PR DESCRIPTION
`let metadataProvider = LPMetadataProvider()` – this line was duplicated