### PR TITLE
Fix URL

### DIFF
--- a/2019-10-31-device-identifiers.md
+++ b/2019-10-31-device-identifiers.md
@@ -211,7 +211,7 @@ _(not that this is a bad thing from the user's perspective!)_
 There's also the curious case of the
 `isAdvertisingTrackingEnabled` property.
 According to
-[the documentation](https://developer.apple.com/documentation/adsupport/asidentifiermanager/1614151-advertisingidentifier):
+[the documentation](https://developer.apple.com/documentation/adsupport/asidentifiermanager/1614148-isadvertisingtrackingenabled):
 
 > Check the value of this property
 > before performing any advertising tracking.


### PR DESCRIPTION
The URL was leading to the documentation of the `advertisingIdentifier`, however `isAdvertisingTrackingEnabled` is discussed.