### PR TITLE
Fixes typo in 2014-05-19-benchmarking.md

### DIFF
--- a/2014-05-19-benchmarking.md
+++ b/2014-05-19-benchmarking.md
@@ -57,7 +57,7 @@ id object = @"🐷";
 
 Benchmarking is as simple as taking the time before running, and comparing it against the time after. `CACurrentMediaTime()` is a convenient way to measure time in seconds derived from `mach_absolute_time`.
 
-> Unlike `NSDate` or `CFAbsoluteTimeGetCurrent()` offsets, `mach_absolute_time()` and `CACurrentMediaTime()` are based on the internal host clock, a precise, monatomic measure, and not subject to changes in the external time reference, such as those caused by time zones, daylight savings, or leap seconds
+> Unlike `NSDate` or `CFAbsoluteTimeGetCurrent()` offsets, `mach_absolute_time()` and `CACurrentMediaTime()` are based on the internal host clock, a precise, monotonic measure, and not subject to changes in the external time reference, such as those caused by time zones, daylight savings, or leap seconds
 
 `for` loops are used to increment `count` and `iterations`. Each iteration is enclosed by an `@autoreleasepool`, to keep the memory footprint low.
 


### PR DESCRIPTION
I am actually not sure what was meant. monotonic? or nonatomic?