### PR TITLE
Correct iPad 11 Pro Max to iPhone

### DIFF
--- a/2019-10-14-swiftui-previews.md
+++ b/2019-10-14-swiftui-previews.md
@@ -394,7 +394,7 @@ import SwiftUI
 
 let deviceNames: [String] = [
     "iPhone SE",
-    "iPad 11 Pro Max",
+    "iPhone 11 Pro Max",
     "iPad Pro (11-inch)"
 ]
 


### PR DESCRIPTION
This PR fixes a small typo in what is a quality & incredibly helpful article - because there is currently no such thing as an "iPad 11 Pro Max", the device shown in the preview pane is another iPhone SE.