### PR TITLE
Update 2018-12-17-bundles-and-packages.md

### DIFF
--- a/2018-12-17-bundles-and-packages.md
+++ b/2018-12-17-bundles-and-packages.md
@@ -276,7 +276,8 @@ func filenameExtensionIsPackage(_ filenameExtension: String) -> Bool {
 }
 
 let xcode = URL(fileURLWithPath: "/Applications/Xcode.app")
-directoryIsPackage(xcode) // true
+let appExtension = xcode.pathExtension // "app"
+filenameExtensionIsPackage(appExtension) // true
 ```
 
 {% info %}


### PR DESCRIPTION
Updated the filename extension example to use the declared method.

Feel free to disregard this, but as I was reading this article it seemed like the example may have been different originally, but was meant to use the above declared method.

Alternatively, instead of using the `xcode` variable at all, we could just provide the `"app"` string to the example method.