### PR TITLE
Update 2019-09-23-ios-13.md

### DIFF
--- a/2019-09-23-ios-13.md
+++ b/2019-09-23-ios-13.md
@@ -569,7 +569,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func scheduleAppRefresh() {
         let request = BGAppRefreshTaskRequest(identifier: backgroundTaskIdentifier)
-        request.earliestBeginDate = Date(timeIntervalSinceNow: 60 * 10)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 60 * 15)
 
         do {
             try BGTaskScheduler.shared.submit(request)


### PR DESCRIPTION
Apple's documentation [here](https://developer.apple.com/documentation/backgroundtasks/bgtaskscheduler) suggests that `earliestBeginDate` should be no earlier than 15 minutes from now.