### PR TITLE
Update 2019-06-24-propertywrapper.md

### DIFF
--- a/2019-06-24-propertywrapper.md
+++ b/2019-06-24-propertywrapper.md
@@ -180,7 +180,7 @@ struct Clamping<Value: Comparable> {
     var value: Value
     let range: ClosedRange<Value>
 
-    init(initialValue value: Value, _ range: ClosedRange<Value>) {
+    init(wrappedValue value: Value, _ range: ClosedRange<Value>) {
         precondition(range.contains(value))
         self.value = value
         self.range = range
@@ -228,7 +228,7 @@ struct UnitInterval<Value: FloatingPoint> {
     @Clamping(0...1)
     var wrappedValue: Value = .zero
 
-    init(initialValue value: Value) {
+    init(wrappedValue value: Value) {
         self.wrappedValue = value
     }
 }
@@ -372,8 +372,8 @@ struct Trimmed {
         set { value = newValue.trimmingCharacters(in: .whitespacesAndNewlines) }
     }
 
-    init(initialValue: String) {
-        self.wrappedValue = initialValue
+    init(wrappedValue value: String) {
+        self.wrappedValue = value
     }
 }
 ```
@@ -390,7 +390,7 @@ struct Post {
     @Trimmed var body: String
 }
 
-let quine = Post(title: "  Swift Property Wrappers  ", body: "<#...#>")
+var quine = Post(title: "  Swift Property Wrappers  ", body: "<#...#>")
 quine.title // "Swift Property Wrappers" (no leading or trailing spaces!)
 
 quine.title = "      @propertyWrapper     "
@@ -648,7 +648,8 @@ struct Versioned<Value> {
         }
     }
 
-    init(initialValue value: Value) {
+    init(wrappedValue value: Value) {
+        self.value = value // self must be initialized before being used on next line
         self.wrappedValue = value
     }
 }
@@ -813,8 +814,8 @@ struct Dasherized {
         set { value = newValue.replacingOccurrences(of: " ", with: "-") }
     }
 
-    init(initialValue: String) {
-        self.wrappedValue = initialValue
+    init(wrappedValue value: String) {
+        self.wrappedValue = value
     }
 }
 


### PR DESCRIPTION
Xcode 11.3 & Swift 5.1, and Xcode 11.4beta1 with Swift 5.2

updated `initialValue` to `wrappedValue` but that doesn't fix all the issues with the samples herein.

`$name = CaseInsensitive(wrappedValue: name)` line gets a compiler error

`Versioned` has the weird extra line of `self.value` that must be added.