### PR TITLE
Update “Never” article reference to Result type

### DIFF
--- a/2018-07-30-never.md
+++ b/2018-07-30-never.md
@@ -123,7 +123,7 @@ conforming this obscure type to `Equatable` and other protocols this way:
 > to represent something that always errors
 > or use `Never` for its `Error` to represent something that never errors.
 
-Swift doesn't have a standard `Result` type,
+Swift didn't have a standard `Result` type at the time,
 but most of them look something like this:
 
 ```swift


### PR DESCRIPTION
At the time of the article Swift didn’t have a standard Result type, I changed the wording to reflect that it now does but didn’t at the time of the evolution proposal the paragraph is talking about. 

Done on mobile so might have missed something or this could be worded better? Use another PR or suggest changes for me to make - no problem either way.