### PR TITLE
Fix a Small Typo - does → dose

### DIFF
--- a/2020-02-12-callable.md
+++ b/2020-02-12-callable.md
@@ -17,7 +17,7 @@ Apple released the [first beta of Xcode 11.4][xcode 11.4 release notes],
 and it's proving to be one of the most substantial updates in recent memory.
 `XCTest` got [a huge boost][xcode 11.4 testing],
 with numerous quality of life improvements,
-and [Simulator][xcode 11.4 simulator], likewise, got a solid does of
+and [Simulator][xcode 11.4 simulator], likewise, got a solid dose of
 <abbr title="tender loving care">TLC</abbr>.
 But it's the changes to Swift that are getting the lion's share of attention.
 


### PR DESCRIPTION
Just fixes a small typo, changing the word does to dose.