### PR TITLE
Updated command to verify toolchain setup

### DIFF
--- a/2018-11-19-vscode.md
+++ b/2018-11-19-vscode.md
@@ -102,7 +102,7 @@ You can verify that everything is working as expected
 by running the `sourcekit-lsp` command:
 
 ```terminal
-$ xcrun sourcekit-lsp
+$ xcrun --toolchain swift sourcekit-lsp
 ```
 
 This command launches a new language server process,


### PR DESCRIPTION
I couldn't verify it using `xcrun sourcekit-lsp`, so I am suggesting what worked for me to verify `xcrun --toolchain swift sourcekit-lsp`