### PR TITLE
Updating verification of sourcekit-lsp

### DIFF
--- a/2018-11-19-vscode.md
+++ b/2018-11-19-vscode.md
@@ -102,7 +102,7 @@ You can verify that everything is working as expected
 by running the `sourcekit-lsp` command:
 
 ```terminal
-$ xcrun sourcekit-lsp
+$ xcrun --toolchain swift sourcekit-lsp
 ```
 
 This command launches a new language server process,


### PR DESCRIPTION
By running xcrun sourcekit-lsp i received the error down below. I hade to run xcrun --toolchain swift sourcekit-lsp which worked.
Maybe someone else will run into that issue. This would help

xcrun: error: sh -c '/Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -find sourcekit-lsp 2> /dev/null' failed with exit code 17664: (null) (errno=No such file or directory)
xcrun: error: unable to find utility "sourcekit-lsp", not a developer tool or in PATH