### PR TITLE
adding explicit parens around find name arguments

### DIFF
--- a/2019-09-02-dark-mode.md
+++ b/2019-09-02-dark-mode.md
@@ -757,7 +757,7 @@ You _could_ go through each by hand and click each of the visual elements...
 or you could run the following command:
 
 ```terminal
-$ find . -name '*.xib' -or -name '*.storyboard' \
+$ find . \( -name '*.xib' -or -name '*.storyboard' \) \
     -exec echo {} \;        \
     -exec xmlstarlet sel -t \
             -m "//color[@colorSpace='custom']" -c . -n  {} \;
@@ -781,7 +781,7 @@ you can generate a sorted, unique'd list of
 every custom color in every XIB or Storyboard:
 
 ```terminal
-$ find . -name '*.xib' -or -name '*.storyboard' \
+$ find . \( -name '*.xib' -or -name '*.storyboard' \) \
     -exec xmlstarlet sel -t \
             -m "//color[@colorSpace='custom']"  \
             -v "concat( @red,'  ',@green,'  ',@blue,'  ',@alpha)" -n  {} \; \


### PR DESCRIPTION
without the explicit parentheses, only storyboard files
are processed. with the explicit parentheses, xibs are processed as well 😎