### PR TITLE
Changed currency code for "Deutsche Mark" to DEM

### DIFF
--- a/2012-09-03-locale.md
+++ b/2012-09-03-locale.md
@@ -117,7 +117,7 @@ language[_region][.character-encoding][@modifier=value[, ...]]
 ```
 
 For example,
-the locale identifier `de_DE.UTF8@collation=phonebook,currency=DDM`
+the locale identifier `de_DE.UTF8@collation=phonebook,currency=DEM`
 specifies a German language locale in Germany
 that uses UTF-8 text encoding,
 [phonebook collation](http://developer.mimer.com/charts/german_phonebook.htm),


### PR DESCRIPTION
DDM was the currency code of https://en.wikipedia.org/wiki/East_German_mark - so updating the meta-information would also be okay, but I suspect a lot more people know about Deutsche Mark.