### PR TITLE
Fix binary being renamed to bin

### DIFF
--- a/2018-12-03-homebrew.md
+++ b/2018-12-03-homebrew.md
@@ -128,6 +128,7 @@ build:
 	swift build -c release --disable-sandbox
 
 install: build
+	install -d "$(bindir)"
 	install ".build/release/swift-syntax-highlight" "$(bindir)"
 	install ".build/release/libSwiftSyntax.dylib" "$(libdir)"
 	install_name_tool -change \

--- a/2018-12-03-homebrew.md
+++ b/2018-12-03-homebrew.md
@@ -128,7 +128,7 @@ build:
 	swift build -c release --disable-sandbox
 
 install: build
-	install -d "$(bindir)"
+	install -d "$(bindir)" "$(libdir)"
 	install ".build/release/swift-syntax-highlight" "$(bindir)"
 	install ".build/release/libSwiftSyntax.dylib" "$(libdir)"
 	install_name_tool -change \


### PR DESCRIPTION
Given a custom prefix, the install command would not create the necessary folders and end up renaming the binary to "bin" when moving it to the destination folder.
So brew would create a binary "/usr/local/Cellar/swift-syntax-highlight/0.1.0/bin" and then fail to symlink it. 
