### PR TITLE
Add note for activityCategory.

### DIFF
--- a/2014-04-21-uiactivityviewcontroller.md
+++ b/2014-04-21-uiactivityviewcontroller.md
@@ -315,6 +315,8 @@ class MustachifyActivity: UIActivity {
 }
 ```
 
+***NOTE FOR activityCategory: Setting this to .action will create the gray rectangle, setting to .share will create the square icon to be shared***
+
 ### Determining Which Items are Actionable
 
 Activities are responsible for determining


### PR DESCRIPTION
New version of Swift (5+) using `.action` will create the simple gray action button not the share icon. Which works great for the example you provided but the picture you show as an example shows the square button. Setting this to `.share` will create the square icon.