### PR TITLE
Update the swiftlint extension for 2018-11-19-vscode.md 

### DIFF
--- a/2018-11-19-vscode.md
+++ b/2018-11-19-vscode.md
@@ -130,7 +130,7 @@ and test out Language Server Protocol support for Swift.
 
 To get the full experience of working with Swift from VSCode,
 we recommend that you also check out
-the [Swift Lint extension](https://marketplace.visualstudio.com/items?itemName=shinnn.swiftlint)
+the [Swift Lint extension](https://marketplace.visualstudio.com/items?itemName=vknabel.vscode-swiftlint)
 (for real-time style and convention diagnostics).
 
 {% endinfo %}


### PR DESCRIPTION
The extension in the article is unpublished as mentioned below:
> This extension is now unpublished from Marketplace. You can choose to uninstall it.

So update to use another extension https://marketplace.visualstudio.com/items?itemName=vknabel.vscode-swiftlint