### PR TITLE
Adds server path section to vscode swift article 

### DIFF
--- a/2018-11-19-vscode.md
+++ b/2018-11-19-vscode.md
@@ -12,7 +12,7 @@ status:
 revisions:
   2020-02-06: Updated for Xcode 11.4
   2020-05-06: Updated for GitHub Codespaces Announcement
-  2020-05-06: Added section on setting  Codespaces Announcement
+  2020-08-17: Added section on setting Server Path value
 ---
 
 [Visual Studio Code (VSCode)](https://code.visualstudio.com)

--- a/2018-11-19-vscode.md
+++ b/2018-11-19-vscode.md
@@ -12,6 +12,7 @@ status:
 revisions:
   2020-02-06: Updated for Xcode 11.4
   2020-05-06: Updated for GitHub Codespaces Announcement
+  2020-05-06: Added section on setting  Codespaces Announcement
 ---
 
 [Visual Studio Code (VSCode)](https://code.visualstudio.com)
@@ -125,6 +126,23 @@ such as [this one](https://github.com/flight-school/money),
 and test out Language Server Protocol support for Swift.
 
 {% asset vscode-swift-lsp-screenshot.png %}
+
+{% warning %}
+
+If you get an error stating `Couldn't start client SourceKit Language Server`,
+you may also need to specify the sourcekit-lsp executable path,
+which you can find using `xcrun`:
+
+```terminal
+$ xcrun --find sourcekit-lsp
+/Library/Developer/CommandLineTools/usr/bin/sourcekit-lsp
+```
+
+Copy the printed value and enter it into the setting for
+**Server Path** under Preferences > Settings, Extensions > SourceKit-LSP,
+and then Reload Window.
+
+{% endwarning %}
 
 {% info %}
 


### PR DESCRIPTION
Adds a section helping guide folks with a common error regarding the sourcekit-lsp extension's Server Path setting.

This seems to be a pretty common obstacle people have, as seen on the Swift forum [1](https://forums.swift.org/t/help-with-setup/21163/5), [2](https://forums.swift.org/t/how-to-use-sourcekit-lsp/34406).