### PR TITLE
Update 2018-11-26-simctl.md

### DIFF
--- a/2018-11-26-simctl.md
+++ b/2018-11-26-simctl.md
@@ -81,7 +81,7 @@ $ xcrun simctl list
 ```
 
 Each device has an associated
-[UUID](https://nshipster.com/uuid-udid-unique-identifier/).
+[UDID](https://nshipster.com/uuid-udid-unique-identifier/).
 You pass this to any of the `simctl` subcommands that take a device parameter.
 
 One such subcommand is `boot`,
@@ -89,12 +89,12 @@ which starts up the specified device,
 making it available for interaction:
 
 ```terminal
-$ xcrun simctl boot $UUID
+$ xcrun simctl boot $UDID
 ```
 
 {% info %}
 Once you've booted a device,
-you can pass the string `"booted"` instead of the UUID
+you can pass the string `"booted"` instead of the UDID
 for subcommands that operate on a particular a device.
 If you pass `"booted"` when multiple devices are booted,
 `simctl` chooses one of them.
@@ -116,7 +116,7 @@ iPhone X (9FED67A2-3D0A-4C9C-88AC-28A9CCA44C60) (Booted)
 ```
 
 To isolate the device identifier,
-you can redirect to `grep` again to search for a UUID pattern:
+you can redirect to `grep` again to search for a UDID pattern:
 
 ```terminal
 $ xcrun simctl list devices | \
@@ -153,8 +153,8 @@ you can shut down and erase its contents
 using the `shutdown` and `erase` subcommands:
 
 ```terminal
-$ xcrun simctl shutdown $UUID
-$ xcrun simctl erase $UUID
+$ xcrun simctl shutdown $UDID
+$ xcrun simctl erase $UDID
 ```
 
 {% info %}
@@ -288,7 +288,7 @@ But knowing how simulators work in Xcode lets you automate this process
 in ways that don't directly involve `simctl`.
 
 For example,
-now that you know that each simulator device has a UUID,
+now that you know that each simulator device has a UDID,
 you can now find the data directory for a device in `~/Library/Developer/CoreSimulator/Devices/`.
 The simulator preferences file
 `data/Library/Preferences/.GlobalPreferences.plist`
@@ -298,7 +298,7 @@ including current locale and languages.
 You can see the contents of this using the `plutil` command:
 
 ```terminal
-$ plutil -p ~/Library/Developer/CoreSimulator/Devices/$UUID/data/Library/Preferences/.GlobalPreferences.plist
+$ plutil -p ~/Library/Developer/CoreSimulator/Devices/$UDID/data/Library/Preferences/.GlobalPreferences.plist
 ```
 
 Here's what you might expect, in JSON format:
@@ -327,7 +327,7 @@ For example, the following shell script
 changes the current locale and language to Japanese:
 
 ```bash
-PLIST=~/Library/Developer/CoreSimulator/Devices/$UUID/data/Library/Preferences/.GlobalPreferences.plist
+PLIST=~/Library/Developer/CoreSimulator/Devices/$UDID/data/Library/Preferences/.GlobalPreferences.plist
 
 LANGUAGE="ja"
 LOCALE="ja_JP"
@@ -344,7 +344,7 @@ To get the full scope of all the available settings,
 run `plutil -p` on all property lists in the preferences directory:
 
 ```terminal
-$ plutil -p ~/Library/Developer/CoreSimulator/Devices/$UUID/data/Library/Preferences/*.plist
+$ plutil -p ~/Library/Developer/CoreSimulator/Devices/$UDID/data/Library/Preferences/*.plist
 ```
 
 ---


### PR DESCRIPTION
Refer to UDID rather than UUID, which is the correct term for a device's identifier according to https://nshipster.com/uuid-udid-unique-identifier and according to the JSON output of `xcrun simctl list devices`, which includes a "udid" key:
```
$ xcrun simctl list devices --json
{
  "devices" : {
    // ...
    "com.apple.CoreSimulator.SimRuntime.iOS-13-3" : [
      {
        // ...
        "udid" : "..."
      },
      // ...
    ]
  }
}
```