### PR TITLE
In IPC article, use same string for port names in client and server

### DIFF
--- a/2014-10-17-inter-process-communication.md
+++ b/2014-10-17-inter-process-communication.md
@@ -99,7 +99,7 @@ static CFDataRef Callback(CFMessagePortRef port,
 
 CFMessagePortRef localPort =
     CFMessagePortCreateLocal(nil,
-                             CFSTR("com.example.app.port.server"),
+                             CFSTR("com.example.app.port"),
                              Callback,
                              nil,
                              nil);
@@ -121,7 +121,7 @@ CFTimeInterval timeout = 10.0;
 
 CFMessagePortRef remotePort =
     CFMessagePortCreateRemote(nil,
-                              CFSTR("com.example.app.port.client"));
+                              CFSTR("com.example.app.port"));
 
 SInt32 status =
     CFMessagePortSendRequest(remotePort,


### PR DESCRIPTION
The name passed to `CFMessagePortCreateRemote` has to be the same name used when the port was created via `CFMessagePortCreateLocal` in the other process. This is a key part in how they figure out how to talk to each other. Otherwise `CFMessagePortCreateRemote` always returns `NULL`/`nil` since a port with the name given to it doesn't exist on the system. The example code might have tried to distinguish between the client and server by using different strings, but this causes the remote port creation to fail.