### PR TITLE
Update 2019-05-06-image-resizing.md

### DIFF
--- a/2019-05-06-image-resizing.md
+++ b/2019-05-06-image-resizing.md
@@ -261,7 +261,7 @@ func resizedImage(at url: URL, for size: CGSize) -> UIImage? {
                             width: Int(size.width),
                             height: Int(size.height),
                             bitsPerComponent: image.bitsPerComponent,
-                            bytesPerRow: image.bytesPerRow,
+                            bytesPerRow: 0,
                             space: image.colorSpace ?? CGColorSpace(name: CGColorSpace.sRGB)!,
                             bitmapInfo: image.bitmapInfo.rawValue)
     context?.interpolationQuality = .high


### PR DESCRIPTION
The current value is incorrect. It passes the number of bytes per row based on the size of the original image, not the size of the target (resized) image.

From docs:

```
bytesPerRow	
The number of bytes of memory to use per row of the bitmap. If the data parameter is NULL, passing a value of 0 causes the value to be calculated automatically.
```

I also ran the performance tests on iPhone 11 Pro running iOS 14.1 and they no longer match the results from the article. The fastest approach is #2 - based on `CGContext`. That matches my expectations. `UIGraphicsImageRendererContext` is simply a wrapper on top of `CGContext.` I don't expect it to be faster.