### PR TITLE
Homebrew Formulas - Ruby Hashrocket Upgrade

### DIFF
--- a/2018-12-03-homebrew.md
+++ b/2018-12-03-homebrew.md
@@ -7,8 +7,6 @@ excerpt: >-
   write and publish a Homebrew formula for it.
 status:
   swift: n/a
-revisions:
-  2020-12-04: Updated Ruby hash syntax away from hashrocket to Ruby 1.9 hashes per Homebrew preferences
 ---
 
 It's not enough to make software;

--- a/2018-12-03-homebrew.md
+++ b/2018-12-03-homebrew.md
@@ -7,6 +7,8 @@ excerpt: >-
   write and publish a Homebrew formula for it.
 status:
   swift: n/a
+revisions:
+  2020-12-04: Updated Ruby hash syntax away from hashrocket to Ruby 1.9 hashes per Homebrew preferences
 ---
 
 It's not enough to make software;

--- a/2018-12-03-homebrew.md
+++ b/2018-12-03-homebrew.md
@@ -206,10 +206,10 @@ class SwiftSyntaxHighlight < Formula
   desc "Syntax highlighter for Swift code"
   homepage "https://github.com/NSHipster/SwiftSyntaxHighlighter"
   url "https://github.com/NSHipster/SwiftSyntaxHighlighter.git",
-      :tag => "0.1.0", :revision => "6c3e2dca81965f902694cff83d361986ad86f443"
+      tag: "0.1.0", revision: "6c3e2dca81965f902694cff83d361986ad86f443"
   head "https://github.com/NSHipster/SwiftSyntaxHighlighter.git"
 
-  depends_on :xcode => ["10.0", :build]
+  depends_on xcode: ["10.0", :build]
 
   def install
     system "make", "install", "prefix=#{prefix}"


### PR DESCRIPTION
Ruby 1.9's simpler non-hashrocket syntax is now preferred by Homebrew for submitted formulae.

I looked for other Ruby hashes and found some in the CocoaPods articles (`Stewardship`, `CocoaPods`) , but I haven't used CocoaPods in a few years so I'm not sure what the convention is there.