### PR TITLE
[GYB Article] Fixed links to Swift repository

### DIFF
--- a/2018-07-09-swift-gyb.md
+++ b/2018-07-09-swift-gyb.md
@@ -54,7 +54,7 @@ Swift doesn’t have a macro system,
 and because the standard library is itself written in Swift,
 it can't take advantage of C++ metaprogramming capabilities.
 Instead, the Swift maintainers use a Python script called
-[gyb.py](https://github.com/apple/swift/blob/master/utils/gyb.py)
+[gyb.py](https://github.com/apple/swift/blob/main/utils/gyb.py)
 to generate source code using a small set of template tags.
 
 {% info do %}
@@ -170,8 +170,8 @@ and use the `chmod` command to make `gyb` executable
 (the default installation of Python on macOS should be able to run `gyb`):
 
 ```terminal
-$ wget https://github.com/apple/swift/raw/master/utils/gyb
-$ wget https://github.com/apple/swift/raw/master/utils/gyb.py
+$ wget https://github.com/apple/swift/raw/main/utils/gyb
+$ wget https://github.com/apple/swift/raw/main/utils/gyb.py
 $ chmod +x gyb
 ```
 


### PR DESCRIPTION
They renamed the master branch to main.