### PR TITLE
Use correct argument name in sample code

### DIFF
--- a/2019-11-12-secrets.md
+++ b/2019-11-12-secrets.md
@@ -270,7 +270,7 @@ enum Secrets {
         % end
         ]
 
-        return decode(encoded, salt: cipher)
+        return decode(encoded, cipher: salt)
     }
 
     <#...#>


### PR DESCRIPTION
The second argument in the `decode` function is named `cipher`, not `salt`.