### PR TITLE
Update 2013-08-26-equality.md

### DIFF
--- a/2013-08-26-equality.md
+++ b/2013-08-26-equality.md
@@ -121,6 +121,10 @@ For example:
 > When comparing two instances of any of these classes,
 > use these high-level methods rather than `isEqual:`.
 
+Beware that the `isEqualTo<#ClassName#>:` methods do *not* accept `nil` as a parameter while `isEqual:` does (and returns `NO` if given `nil`).
+
+Also beware of the `-isEqualTo:` category method declared in `NSScriptWhoseTests.h`.  It's a whole other unrelated thing, despite its very similar name.
+
 Types that encapsulate a single value,
 such as `NSDate`,
 perform an equality comparison of that value.
@@ -155,7 +159,11 @@ the actual implementation would be significantly more complicated):
   return YES;
 }
 
-- (BOOL)isEqual:(id)object {
+- (BOOL)isEqual:(nullable id)object {
+  if (object == nil) {
+    return NO;
+  }
+
   if (self == object) {
     return YES;
   }
@@ -328,7 +336,7 @@ do the following:
 - Implement a new `isEqualTo<#ClassName#>:` method
   to test for value equality.
 - Override the `isEqual:` method,
-  starting with early class and object identity checks
+  starting with early nil check and class and object identity checks
   and falling back on the aforementioned value equality test.
 - Override the `hash` method such that equal objects
   produce the same hash value.
@@ -372,11 +380,15 @@ In the case of a `Color`, that means checking the
 
 The `isEqual:` method should delegate to
 the `isEqualTo<#ClassName#>:` method
-after testing for pointer equality
+after testing for nil argument, pointer equality,
 and checking for type identity:
 
 ```objc
-- (BOOL)isEqual:(id)object {
+- (BOOL)isEqual:(nullable id)object {
+    if (object == nil) {
+        return NO;
+    }
+
     if (self == object) {
         return YES;
     }


### PR DESCRIPTION
- Updated to account for isEqual: accepting nil.
- Noted that isEqualTo<ClassName>: does *not* accept nil.
- Noted existence of deceptive isEqualTo: method.