### PR TITLE
Fix incorrect llama leetspeak in 2025-02-14-ollama.md

### DIFF
--- a/2025-02-14-ollama.md
+++ b/2025-02-14-ollama.md
@@ -136,7 +136,7 @@ there's something to be said for the small miracle of running open models locall
 
 ## Building macOS Apps with Ollama
 
-Ollama also exposes an [HTTP API](https://github.com/ollama/ollama/blob/main/docs/api.md) on port 11431
+Ollama also exposes an [HTTP API](https://github.com/ollama/ollama/blob/main/docs/api.md) on port 11434
 ([leetspeak](https://en.wikipedia.org/wiki/Leet) for llama 🦙).
 This makes it easy to integrate with any programming language or tool.
 


### PR DESCRIPTION
The actual port, from the official documentation, is 11434.